### PR TITLE
CI: fix building docs for release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,9 +32,11 @@ jobs:
         python setup.py sdist bdist_wheel
         python -m twine upload dist/*
 
-    # Docuemntation
+    # Documentation
     - name: Install doc dependencies
       run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends --yes libsndfile1 sox
         pip install -r requirements.txt
         pip install -r docs/requirements.txt
 


### PR DESCRIPTION
Fixes #7 

`audinterface` needs `libsndfile` and `sox` for import.
Most probably we could also mock them during import, but I'm too lazy and just install them here for building the documentation.