### PR TITLE
Fix unit in pd.to_timedelta()

### DIFF
--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -317,9 +317,7 @@ class Process:
         if start is None or pd.isna(start):
             start = pd.to_timedelta(0)
         if end is None or (pd.isna(end) and not self.keep_nat):
-            end = pd.to_timedelta(
-                signal.shape[-1] / sampling_rate, unit='sec'
-            )
+            end = pd.to_timedelta(signal.shape[-1] / sampling_rate, unit='s')
         start_i, end_i = utils.segment_to_indices(
             signal, sampling_rate, start, end,
         )

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -108,9 +108,7 @@ def segment_to_indices(
         end: pd.Timedelta,
 ) -> typing.Tuple[int, int]:
     if pd.isna(end):
-        end = pd.to_timedelta(
-            signal.shape[-1] / sampling_rate, unit='sec'
-        )
+        end = pd.to_timedelta(signal.shape[-1] / sampling_rate, unit='s')
     max_i = signal.shape[-1]
     start_i = int(round(start.total_seconds() * sampling_rate))
     start_i = min(start_i, max_i)

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -29,7 +29,7 @@ SEGMENT = audinterface.Segment(
                     pd.to_timedelta(0),
                 ],
                 [
-                    pd.to_timedelta(x.shape[1] / sr, unit='sec') / 2,
+                    pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
                 ],
             ],
             names=['start', 'end'],
@@ -181,7 +181,7 @@ def test_process_file(tmpdir, start, end, segment):
     if start is None or pd.isna(start):
         start = pd.to_timedelta(0)
     if end is None or pd.isna(end):
-        end = pd.to_timedelta(af.duration(file), unit='sec')
+        end = pd.to_timedelta(af.duration(file), unit='s')
 
     if segment is not None:
         index = segment.process_file(file)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -26,7 +26,7 @@ SEGMENT = audinterface.Segment(
                     pd.to_timedelta(0),
                 ],
                 [
-                    pd.to_timedelta(x.shape[1] / sr, unit='sec') / 2,
+                    pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
                 ],
             ],
             names=['start', 'end'],
@@ -989,7 +989,7 @@ def test_process_signal_from_index(
                             pd.to_timedelta(0),
                         ],
                         [
-                            pd.to_timedelta(x.shape[1] / sr, unit='sec') / 2,
+                            pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
                         ],
                     ],
                     names=['start', 'end'],
@@ -1000,10 +1000,10 @@ def test_process_signal_from_index(
             pd.MultiIndex.from_arrays(
                 [
                     [
-                        pd.to_timedelta(x.shape[1] / sr, unit='sec') / 2,
+                        pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
                     ],
                     [
-                        pd.to_timedelta(x.shape[1] / sr, unit='sec'),
+                        pd.to_timedelta(x.shape[1] / sr, unit='s'),
                     ],
                 ],
                 names=['start', 'end'],
@@ -1015,10 +1015,10 @@ def test_process_signal_from_index(
                     [
                         [
                             pd.to_timedelta(0),
-                            pd.to_timedelta(x.shape[1] / sr, unit='sec') / 2,
+                            pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
                         ],
                         [
-                            pd.to_timedelta(x.shape[1] / sr, unit='sec') / 2,
+                            pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
                             pd.to_timedelta(x.shape[1] / sr),
                         ],
                     ],


### PR DESCRIPTION
Use `unit='s'`  instead of `'sec'` when converting seconds with `pd.to_timedelta()`.

Reason: it seems that some (older?) versions of `pandas` do not support `'sec'`, see e.g. https://github.com/audeering/opensmile-python/issues/32#issuecomment-850786628