### PR TITLE
Add root argument

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -183,6 +183,7 @@ class Feature:
             *,
             start: Timestamp = None,
             end: Timestamp = None,
+            root: str = None,
     ) -> pd.DataFrame:
         r"""Extract features from an audio file.
 
@@ -192,13 +193,19 @@ class Feature:
                 If value is as a float or integer it is treated as seconds
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds
+            root: root folder to expand relative file path
 
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
 
         """
-        series = self.process.process_file(file, start=start, end=end)
+        series = self.process.process_file(
+            file,
+            start=start,
+            end=end,
+            root=root,
+        )
         return self._series_to_frame(series)
 
     def process_files(
@@ -207,6 +214,7 @@ class Feature:
             *,
             starts: Timestamps = None,
             ends: Timestamps = None,
+            root: str = None,
     ) -> pd.DataFrame:
         r"""Extract features for a list of files.
 
@@ -218,13 +226,19 @@ class Feature:
             ends: segment end positions.
                 Time values given as float or integers are treated as seconds
                 If a scalar is given, it is applied to all files
+            root: root folder to expand relative file paths
 
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
 
         """
-        series = self.process.process_files(files, starts=starts, ends=ends)
+        series = self.process.process_files(
+            files,
+            starts=starts,
+            ends=ends,
+            root=root,
+        )
         return self._series_to_frame(series)
 
     def process_folder(
@@ -253,11 +267,14 @@ class Feature:
     def process_index(
             self,
             index: pd.Index,
+            *,
+            root: str = None,
     ) -> pd.DataFrame:
         r"""Extract features from an index conform to audformat_.
 
         Args:
             index: index with segment information
+            root: root folder to expand relative file paths
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -267,7 +284,7 @@ class Feature:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        series = self.process.process_index(index)
+        series = self.process.process_index(index, root=root)
         return self._series_to_frame(series)
 
     def process_signal(

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -193,6 +193,7 @@ class Segment:
             *,
             start: Timestamp = None,
             end: Timestamp = None,
+            root: str = None,
     ) -> pd.Index:
         r"""Segment the content of an audio file.
 
@@ -202,6 +203,7 @@ class Segment:
                 If value is as a float or integer it is treated as seconds
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds
+            root: root folder to expand relative file path
 
         Returns:
             Segmented index conform to audformat_
@@ -215,7 +217,12 @@ class Segment:
         """
         if start is None or pd.isna(start):
             start = pd.to_timedelta(0)
-        index = self.process.process_file(file, start=start, end=end).values[0]
+        index = self.process.process_file(
+            file,
+            start=start,
+            end=end,
+            root=root,
+        ).values[0]
         return pd.MultiIndex(
             levels=[
                 [file],
@@ -236,6 +243,7 @@ class Segment:
             *,
             starts: Timestamps = None,
             ends: Timestamps = None,
+            root: str = None,
     ) -> pd.Index:
         r"""Segment a list of files.
 
@@ -247,6 +255,7 @@ class Segment:
             ends: segment end positions.
                 Time values given as float or integers are treated as seconds
                 If a scalar is given, it is applied to all files
+            root: root folder to expand relative file paths
 
         Returns:
             Segmented index conform to audformat_
@@ -258,7 +267,12 @@ class Segment:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        series = self.process.process_files(files, starts=starts, ends=ends)
+        series = self.process.process_files(
+            files,
+            starts=starts,
+            ends=ends,
+            root=root,
+        )
         objs = []
         for idx, ((file, start, _), index) in enumerate(series.items()):
             objs.append(
@@ -309,11 +323,14 @@ class Segment:
     def process_index(
             self,
             index: pd.Index,
+            *,
+            root: str = None,
     ) -> pd.Index:
         r"""Segment files or segments from an index.
 
         Args:
             index: index conform to audformat_
+            root: root folder to expand relative file paths
 
         Returns:
             Segmented index conform to audformat_
@@ -335,6 +352,7 @@ class Segment:
             index.get_level_values('file'),
             starts=index.get_level_values('start'),
             ends=index.get_level_values('end'),
+            root=root,
         )
 
     def process_signal(

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -1,3 +1,4 @@
+import os
 import typing
 
 import numpy as np
@@ -65,22 +66,28 @@ def preprocess_signal(
 
 
 def read_audio(
-        path: str,
+        file: str,
+        *,
         start: pd.Timedelta = None,
         end: pd.Timedelta = None,
+        root: str = None,
 ) -> typing.Tuple[np.ndarray, int]:
     """Reads (segment of an) audio file.
 
     Args:
-        path: path to audio file
+        file: path to audio file
         start: read from this position
         end: read until this position
+        root: root folder
 
     Returns:
         signal: array with signal values in shape ``(channels, samples)``
         sampling_rate: sampling rate in Hz
 
     """
+    if root is not None and not os.path.isabs(file):
+        file = os.path.join(root, file)
+
     if start is None or pd.isna(start):
         offset = 0
     else:
@@ -92,7 +99,7 @@ def read_audio(
         duration = end.total_seconds() - offset
 
     signal, sampling_rate = af.read(
-        audeer.safe_path(path),
+        audeer.safe_path(file),
         always_2d=True,
         offset=offset,
         duration=duration,


### PR DESCRIPTION
Closes #9 

Adds `root` argument to all functions that work on file input.

### Examples

```python
db = audb.load(
    'emodb',
    version='1.1.1',
    format='wav',
    mixdown=True,
    sampling_rate=16000,
    full_path=False,
)
files = db.files[:10]
```
```
Index(['wav/03a01Fa.wav', 'wav/03a01Nc.wav', 'wav/03a01Wa.wav',
       'wav/03a02Fc.wav', 'wav/03a02Nc.wav', 'wav/03a02Ta.wav',
       'wav/03a02Wb.wav', 'wav/03a02Wc.wav', 'wav/03a04Ad.wav',
       'wav/03a04Fd.wav'],
      dtype='object', name='file')
```

```python
segment = audinterface.Segment(
    process_func=lambda x, sr: pd.MultiIndex.from_arrays(
        [
            [pd.to_timedelta(0)],
            [pd.to_timedelta(1, unit='s')],
        ],
        names=['start', 'end'],
    )
)
segment.process_index(files, root=db.root)
```
```
MultiIndex([('wav/03a01Fa.wav', '0 days', '0 days 00:00:01'),
            ('wav/03a01Nc.wav', '0 days', '0 days 00:00:01'),
            ('wav/03a01Wa.wav', '0 days', '0 days 00:00:01'),
            ('wav/03a02Fc.wav', '0 days', '0 days 00:00:01'),
            ('wav/03a02Nc.wav', '0 days', '0 days 00:00:01'),
            ('wav/03a02Ta.wav', '0 days', '0 days 00:00:01'),
            ('wav/03a02Wb.wav', '0 days', '0 days 00:00:01'),
            ('wav/03a02Wc.wav', '0 days', '0 days 00:00:01'),
            ('wav/03a04Ad.wav', '0 days', '0 days 00:00:01'),
            ('wav/03a04Fd.wav', '0 days', '0 days 00:00:01')],
           names=['file', 'start', 'end'])
```

```python
process = audinterface.Process(
    process_func=lambda x, sr: x.mean(),
    segment=segment,
)
process.process_index(files, root=db.root)
```
```
file             start   end            
wav/03a01Fa.wav  0 days  0 days 00:00:01   -0.000329
wav/03a01Nc.wav  0 days  0 days 00:00:01    0.000039
wav/03a01Wa.wav  0 days  0 days 00:00:01   -0.000284
wav/03a02Fc.wav  0 days  0 days 00:00:01   -0.000135
wav/03a02Nc.wav  0 days  0 days 00:00:01   -0.000211
wav/03a02Ta.wav  0 days  0 days 00:00:01   -0.001045
wav/03a02Wb.wav  0 days  0 days 00:00:01   -0.000288
wav/03a02Wc.wav  0 days  0 days 00:00:01   -0.000178
wav/03a04Ad.wav  0 days  0 days 00:00:01   -0.000301
wav/03a04Fd.wav  0 days  0 days 00:00:01   -0.000196
dtype: float64
```

```python
feature = audinterface.Feature(
    ['mean'],
    process_func=lambda x, sr: np.atleast_2d(np.array(x.mean())),
    segment=segment,
)
feature.process_index(files, root=db.root)
```
```
                                            mean
file            start  end                      
wav/03a01Fa.wav 0 days 0 days 00:00:01 -0.000329
wav/03a01Nc.wav 0 days 0 days 00:00:01  0.000039
wav/03a01Wa.wav 0 days 0 days 00:00:01 -0.000284
wav/03a02Fc.wav 0 days 0 days 00:00:01 -0.000135
wav/03a02Nc.wav 0 days 0 days 00:00:01 -0.000211
wav/03a02Ta.wav 0 days 0 days 00:00:01 -0.001045
wav/03a02Wb.wav 0 days 0 days 00:00:01 -0.000288
wav/03a02Wc.wav 0 days 0 days 00:00:01 -0.000178
wav/03a04Ad.wav 0 days 0 days 00:00:01 -0.000301
wav/03a04Fd.wav 0 days 0 days 00:00:01 -0.000196
```