### PR TITLE
Add utils.signal_index()

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -13,6 +13,7 @@ from audinterface.core.typing import (
     Timestamp,
     Timestamps,
 )
+import audinterface.core.utils as utils
 
 
 class Feature:
@@ -507,10 +508,7 @@ class Feature:
             ends = [end]
 
         if file is None:
-            index = pd.MultiIndex.from_arrays(
-                [starts, ends],
-                names=['start', 'end'],
-            )
+            index = utils.signal_index(starts, ends)
         else:
             files = [file] * len(starts)
             index = audformat.segmented_index(files, starts, ends)

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -345,6 +345,7 @@ class Feature:
             index: a :class:`pandas.MultiIndex` with two levels
                 named `start` and `end` that hold start and end
                 positions as :class:`pandas.Timedelta` objects.
+                See also :func:`audinterface.utils.signal_index`
 
         Raises:
             RuntimeError: if sampling rates do not match

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -346,9 +346,7 @@ class Process:
         if file is not None:
             index = audformat.segmented_index(file, start, end)
         else:
-            index = pd.MultiIndex.from_tuples(
-                [(start, end)], names=['start', 'end']
-            )
+            index = utils.signal_index(start, end)
 
         return pd.Series([y], index)
 
@@ -474,7 +472,7 @@ class Process:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        utils.check_index(index)
+        utils.assert_index(index)
 
         if index.empty:
             return pd.Series(None, index=index, dtype=float)
@@ -521,7 +519,7 @@ class Process:
         """
 
         index = audformat.utils.to_segmented_index(index)
-        utils.check_index(index)
+        utils.assert_index(index)
 
         if index.empty:
             return pd.Series(None, index=index, dtype=float)
@@ -741,7 +739,7 @@ class ProcessWithContext:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        utils.check_index(index)
+        utils.assert_index(index)
 
         starts_i, ends_i = utils.segments_to_indices(
             signal, sampling_rate, index,

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -461,6 +461,7 @@ class Process:
                 or a :class:`pandas.MultiIndex` with two levels
                 named `start` and `end` that hold start and end
                 positions as :class:`pandas.Timedelta` objects.
+                See also :func:`audinterface.utils.signal_index`
 
         Returns:
             Series with processed segments conform to audformat_
@@ -728,6 +729,7 @@ class ProcessWithContext:
             index: a :class:`pandas.MultiIndex` with two levels
                 named `start` and `end` that hold start and end
                 positions as :class:`pandas.Timedelta` objects.
+                See also :func:`audinterface.utils.signal_index`
 
         Returns:
             Series with processed segments conform to audformat_

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -410,6 +410,7 @@ class Segment:
                 or a :class:`pandas.MultiIndex` with two levels
                 named `start` and `end` that hold start and end
                 positions as :class:`pandas.Timedelta` objects.
+                See also :func:`audinterface.utils.signal_index`
 
         Returns:
             Segmented index conform to audformat_

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -22,13 +22,7 @@ def create_process_func(
 
     if process_func is None:
         def process_func(signal, sr, **kwargs):
-            return pd.MultiIndex.from_arrays(
-                [
-                    pd.to_timedelta([]),
-                    pd.to_timedelta([]),
-                ],
-                names=['start', 'end'],
-            )
+            return utils.signal_index()
 
     if invert:
         def process_func_invert(signal, sr, **kwargs):
@@ -53,13 +47,7 @@ def invert_index(
 
     """
     if index.empty:
-        return pd.MultiIndex.from_arrays(
-            [
-                [pd.to_timedelta(0)],
-                [dur],
-            ],
-            names=['start', 'end'],
-        )
+        return utils.signal_index(0, dur)
 
     starts = index.get_level_values('start')
     ends = index.get_level_values('end')
@@ -71,13 +59,7 @@ def invert_index(
     if ends[-1] != dur:
         new_starts = new_starts.insert(len(new_starts), ends[-1])
         new_ends = new_ends.insert(len(new_ends), dur)
-    return pd.MultiIndex.from_arrays(
-        [
-            new_starts,
-            new_ends,
-        ],
-        names=['start', 'end'],
-    )
+    return utils.signal_index(new_starts, new_ends)
 
 
 def merge_index(
@@ -108,13 +90,7 @@ def merge_index(
     new_starts.append(new_start)
     new_ends.append(new_end)
 
-    return pd.MultiIndex.from_arrays(
-        [
-            new_starts,
-            new_ends,
-        ],
-        names=['start', 'end'],
-    )
+    return utils.signal_index(new_starts, new_ends)
 
 
 class Segment:
@@ -343,7 +319,7 @@ class Segment:
 
         """
         index = audformat.utils.to_segmented_index(index)
-        utils.check_index(index)
+        utils.assert_index(index)
 
         if index.empty:
             return index
@@ -396,7 +372,7 @@ class Segment:
             start=start,
             end=end,
         ).values[0]
-        utils.check_index(index)
+        utils.assert_index(index)
         if start is not None:
             index = index.set_levels(
                 [
@@ -445,7 +421,7 @@ class Segment:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        utils.check_index(index)
+        utils.assert_index(index)
 
         if index.empty:
             return index

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -163,6 +163,12 @@ def signal_index(
     Returns a segmented index like
     :func:`audformat.segmented_index`,
     but without the ``'file'`` level.
+    Can be used with the following methods:
+
+    * :meth:`audinterface.Feature.process_signal_from_index`
+    * :meth:`audinterface.Process.process_signal_from_index`
+    * :meth:`audinterface.ProcessWithContext.process_signal_from_index`
+    * :meth:`audinterface.Segment.process_signal_from_index`
 
     Args:
         starts: segment start positions.

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -160,6 +160,10 @@ def signal_index(
 ) -> pd.MultiIndex:
     r"""Create signal index.
 
+    Returns a segmented index like
+    :func:`audformat.segmented_index`,
+    but without the ``'file'`` level.
+
     Args:
         starts: segment start positions.
             Time values given as float or integers are treated as seconds
@@ -167,10 +171,7 @@ def signal_index(
             Time values given as float or integers are treated as seconds
 
     Returns:
-        signal index
-
-    Raises:
-        ValueError: if created index contains duplicates
+        index with start and end times
 
     Raises:
         ValueError: if ``start`` and ``ends`` differ in size
@@ -192,6 +193,14 @@ def signal_index(
         ... )
         MultiIndex([('0 days 00:00:00', '0 days 00:00:01'),
                     ('0 days 00:00:01', '0 days 00:00:02')],
+                   names=['start', 'end'])
+        >>> signal_index([0, 1])
+        MultiIndex([('0 days 00:00:00', NaT),
+                    ('0 days 00:00:01', NaT)],
+                   names=['start', 'end'])
+        >>> signal_index(ends=[1, 2])
+        MultiIndex([('0 days', '0 days 00:00:01'),
+                    ('0 days', '0 days 00:00:02')],
                    names=['start', 'end'])
 
     """

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -12,24 +12,40 @@ import audiofile as af
 from audinterface.core.typing import Timestamps
 
 
-def check_index(index: pd.Index):
+def assert_index(obj: pd.Index):
     r"""Check if index is conform to audformat."""
-    if isinstance(index, pd.MultiIndex) and len(index.levels) == 2:
-        if not index.empty:
-            if not pd.core.dtypes.common.is_datetime_or_timedelta_dtype(
-                    index.levels[0]
-            ):
-                raise ValueError(f'Level 0 has type '
-                                 f'{type(index.levels[0].dtype)}'
-                                 f', expected timedelta64[ns].')
-            if not pd.core.dtypes.common.is_datetime_or_timedelta_dtype(
-                    index.levels[1]
-            ):
-                raise ValueError(f'Level 1 has type '
-                                 f'{type(index.levels[1].dtype)}'
-                                 f', expected timedelta64[ns].')
+
+    if isinstance(obj, pd.MultiIndex) and len(obj.levels) == 2:
+        if not (
+                obj.names[0] == audformat.define.IndexField.START
+                and obj.names[1] == audformat.define.IndexField.END
+        ):
+            expected_names = [
+                audformat.define.IndexField.START,
+                audformat.define.IndexField.END,
+            ]
+            raise ValueError(
+                'Found two levels with names '
+                f'{obj.names}, '
+                f'but expected names '
+                f'{expected_names}.'
+            )
+        if not pd.api.types.is_timedelta64_dtype(obj.levels[0].dtype):
+            raise ValueError(
+                "Level 'start' must contain values of type 'timedelta64[ns]'."
+            )
+        if not pd.api.types.is_timedelta64_dtype(obj.levels[1].dtype):
+            raise ValueError(
+                "Level 'end' must contain values of type 'timedelta64[ns]'."
+            )
     else:
-        audformat.assert_index(index)
+        audformat.assert_index(obj)
+
+
+def is_scalar(value: typing.Any) -> bool:
+    r"""Check if value is scalar"""
+    return (value is not None) and \
+           (isinstance(value, str) or not hasattr(value, '__len__'))
 
 
 def preprocess_signal(
@@ -136,6 +152,90 @@ def segments_to_indices(
         starts_i[idx] = start_i
         ends_i[idx] = end_i
     return starts_i, ends_i
+
+
+def signal_index(
+        starts: Timestamps = None,
+        ends: Timestamps = None,
+) -> pd.MultiIndex:
+    r"""Create signal index.
+
+    Args:
+        starts: segment start positions.
+            Time values given as float or integers are treated as seconds
+        ends: segment end positions.
+            Time values given as float or integers are treated as seconds
+
+    Returns:
+        signal index
+
+    Raises:
+        ValueError: if created index contains duplicates
+
+    Raises:
+        ValueError: if ``start`` and ``ends`` differ in size
+
+    Example:
+        >>> signal_index(0, 1.1)
+        MultiIndex([('0 days', '0 days 00:00:01.100000')],
+                   names=['start', 'end'])
+        >>> signal_index('0ms', '1ms')
+        MultiIndex([('0 days', '0 days 00:00:00.001000')],
+                   names=['start', 'end'])
+        >>> signal_index([None, 1], [1, None])
+        MultiIndex([(              NaT, '0 days 00:00:01'),
+                    ('0 days 00:00:01',              NaT)],
+                   names=['start', 'end'])
+        >>> signal_index(
+        ...     starts=[0, 1],
+        ...     ends=pd.to_timedelta([1000, 2000], unit='ms'),
+        ... )
+        MultiIndex([('0 days 00:00:00', '0 days 00:00:01'),
+                    ('0 days 00:00:01', '0 days 00:00:02')],
+                   names=['start', 'end'])
+
+    """
+    starts = to_array(starts)
+    ends = to_array(ends)
+
+    if starts is None:
+        if ends is not None:
+            starts = [0] * len(ends)
+        else:
+            starts = []
+
+    if ends is None:
+        ends = [pd.NaT] * len(starts)
+
+    if len(starts) != len(ends):
+        raise ValueError(
+            f"Cannot create index,"
+            f"'starts' and 'ends' differ in length: "
+            f"{len(starts)} != {len(ends)}.",
+        )
+
+    index = pd.MultiIndex.from_arrays(
+        [
+            to_timedelta(starts),
+            to_timedelta(ends),
+        ],
+        names=[
+            audformat.define.IndexField.START,
+            audformat.define.IndexField.END,
+        ])
+    assert_index(index)
+
+    return index
+
+
+def to_array(value: typing.Any) -> typing.Union[list, np.ndarray]:
+    r"""Convert value to list or array."""
+    if value is not None:
+        if isinstance(value, (pd.Series, pd.DataFrame, pd.Index)):
+            value = value.to_numpy()
+        elif is_scalar(value):
+            value = [value]
+    return value
 
 
 def to_timedelta(times: Timestamps):

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -231,19 +231,20 @@ def signal_index(
         names=[
             audformat.define.IndexField.START,
             audformat.define.IndexField.END,
-        ])
+        ],
+    )
     assert_index(index)
 
     return index
 
 
-def to_array(value: typing.Any) -> typing.Union[list, np.ndarray]:
-    r"""Convert value to list or array."""
+def to_array(value: typing.Any) -> np.ndarray:
+    r"""Convert value to numpy array."""
     if value is not None:
         if isinstance(value, (pd.Series, pd.DataFrame, pd.Index)):
             value = value.to_numpy()
         elif is_scalar(value):
-            value = [value]
+            value = np.array([value])
     return value
 
 

--- a/audinterface/utils/__init__.py
+++ b/audinterface/utils/__init__.py
@@ -1,3 +1,4 @@
 from audinterface.core.utils import (
+    signal_index,
     read_audio,
 )

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -7,3 +7,10 @@ read_audio
 ----------
 
 .. autofunction:: read_audio
+
+
+signal_index
+------------
+
+.. autofunction:: signal_index
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,6 +34,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://docs.scipy.org/doc/numpy/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'audformat': ('https://audeering.github.io/audformat/', None),
     'audresample': ('https://audeering.github.io/audresample/', None),
 }
 # Disable Gitlab as we need to sign in

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -20,16 +20,9 @@ def signal_max(signal, sampling_rate):
 
 SEGMENT = audinterface.Segment(
     process_func=lambda x, sr:
-        pd.MultiIndex.from_arrays(
-            [
-                [
-                    pd.to_timedelta(0),
-                ],
-                [
-                    pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                ],
-            ],
-            names=['start', 'end'],
+        audinterface.utils.signal_index(
+            pd.to_timedelta(0),
+            pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
         )
 )
 
@@ -874,9 +867,7 @@ def test_process_signal(
     if file is None:
         y = pd.Series(
             [expected_signal],
-            index=pd.MultiIndex.from_arrays(
-                [[start], [end]], names=['start', 'end']
-            ),
+            index=audinterface.utils.signal_index(start, end),
         )
     else:
         y = pd.Series(
@@ -901,49 +892,31 @@ def test_process_signal(
             None,
             np.random.random(5 * 44100),
             44100,
-            pd.MultiIndex.from_arrays(
-                [
-                    pd.to_timedelta([]),
-                    pd.to_timedelta([]),
-                ],
-                names=['start', 'end']
-            ),
+            audinterface.utils.signal_index(),
         ),
         (
             None,
             np.random.random(5 * 44100),
             44100,
-            pd.MultiIndex.from_arrays(
-                [
-                    pd.timedelta_range('0s', '3s', 3),
-                    pd.timedelta_range('1s', '4s', 3),
-                ],
-                names=['start', 'end']
+            audinterface.utils.signal_index(
+                pd.timedelta_range('0s', '3s', 3),
+                pd.timedelta_range('1s', '4s', 3)
             ),
         ),
         (
             signal_max,
             np.random.random(5 * 44100),
             44100,
-            pd.MultiIndex.from_arrays(
-                [
-                    pd.timedelta_range('0s', '3s', 3),
-                    pd.timedelta_range('1s', '4s', 3),
-                ],
-                names=['start', 'end']
+            audinterface.utils.signal_index(
+                pd.timedelta_range('0s', '3s', 3),
+                pd.timedelta_range('1s', '4s', 3),
             ),
         ),
         (
             signal_max,
             np.random.random(5 * 44100),
             44100,
-            pd.MultiIndex.from_arrays(
-                [
-                    pd.to_timedelta([]),
-                    pd.to_timedelta([]),
-                ],
-                names=['start', 'end']
-            ),
+            audinterface.utils.signal_index(),
         ),
         pytest.param(
             signal_max,
@@ -1020,54 +993,33 @@ def test_process_signal_from_index(
     'segment',
     [
         audinterface.Segment(
+            process_func=lambda x, sr: audinterface.utils.signal_index()
+        ),
+        audinterface.Segment(
             process_func=lambda x, sr:
-                pd.MultiIndex.from_arrays(
-                    [pd.to_timedelta([]), pd.to_timedelta([])],
-                    names=['start', 'end'],
+                audinterface.utils.signal_index(
+                    pd.to_timedelta(0),
+                    pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
                 )
         ),
         audinterface.Segment(
             process_func=lambda x, sr:
-                pd.MultiIndex.from_arrays(
-                    [
-                        [
-                            pd.to_timedelta(0),
-                        ],
-                        [
-                            pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                        ],
-                    ],
-                    names=['start', 'end'],
-                )
-        ),
-        audinterface.Segment(
-            process_func=lambda x, sr:
-            pd.MultiIndex.from_arrays(
-                [
-                    [
-                        pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                    ],
-                    [
-                        pd.to_timedelta(x.shape[1] / sr, unit='s'),
-                    ],
-                ],
-                names=['start', 'end'],
+            audinterface.utils.signal_index(
+                pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
+                pd.to_timedelta(x.shape[1] / sr, unit='s'),
             )
         ),
         audinterface.Segment(
             process_func=lambda x, sr:
-                pd.MultiIndex.from_arrays(
+                audinterface.utils.signal_index(
                     [
-                        [
-                            pd.to_timedelta(0),
-                            pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                        ],
-                        [
-                            pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                            pd.to_timedelta(x.shape[1] / sr),
-                        ],
+                        pd.to_timedelta(0),
+                        pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
                     ],
-                    names=['start', 'end'],
+                    [
+                        pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
+                        pd.to_timedelta(x.shape[1] / sr),
+                    ],
                 )
         )
     ]

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -81,25 +81,16 @@ def test_process_index(tmpdir):
             None,
             np.random.random(5 * 44100),
             44100,
-            pd.MultiIndex.from_arrays(
-                [
-                    pd.to_timedelta([]),
-                    pd.to_timedelta([]),
-                ],
-                names=['start', 'end']
-            ),
+            audinterface.utils.signal_index(),
         ),
         (
             None,
             None,
             np.random.random(5 * 44100),
             44100,
-            pd.MultiIndex.from_arrays(
-                [
-                    pd.timedelta_range('0s', '3s', 3),
-                    pd.timedelta_range('1s', '4s', 3),
-                ],
-                names=['start', 'end']
+            audinterface.utils.signal_index(
+                pd.timedelta_range('0s', '3s', 3),
+                pd.timedelta_range('1s', '4s', 3),
             ),
         ),
         (
@@ -107,12 +98,9 @@ def test_process_index(tmpdir):
             signal_max_with_context,
             np.random.random(5 * 44100),
             44100,
-            pd.MultiIndex.from_arrays(
-                [
-                    pd.timedelta_range('0s', '3s', 3),
-                    pd.timedelta_range('1s', '4s', 3),
-                ],
-                names=['start', 'end']
+            audinterface.utils.signal_index(
+                pd.timedelta_range('0s', '3s', 3),
+                pd.timedelta_range('1s', '4s', 3),
             ),
         ),
         (
@@ -120,13 +108,7 @@ def test_process_index(tmpdir):
             signal_max_with_context,
             np.random.random(5 * 44100),
             44100,
-            pd.MultiIndex.from_arrays(
-                [
-                    pd.to_timedelta([]),
-                    pd.to_timedelta([]),
-                ],
-                names=['start', 'end']
-            ),
+            audinterface.utils.signal_index(),
         ),
         pytest.param(
             signal_max,
@@ -257,11 +239,8 @@ def test_sampling_rate_mismatch(
         verbose=False,
     )
     signal = np.random.random(5 * 44100)
-    index = pd.MultiIndex.from_arrays(
-        [
-            pd.timedelta_range('0s', '3s', 3),
-            pd.timedelta_range('1s', '4s', 3),
-        ],
-        names=['start', 'end']
+    index = audinterface.utils.signal_index(
+        pd.timedelta_range('0s', '3s', 3),
+        pd.timedelta_range('1s', '4s', 3),
     )
     model.process_signal_from_index(signal, signal_sampling_rate, index)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,123 @@
+import pandas as pd
+import pytest
+
+import audformat
+import audinterface
+
+
+def to_array(value):
+    if value is not None:
+        if isinstance(value, (pd.Series, pd.DataFrame, pd.Index)):
+            value = value.tolist()
+        elif not isinstance(value, list):
+            value = [value]
+    return value
+
+
+@pytest.mark.parametrize(
+    'obj',
+    [
+        audinterface.utils.signal_index(),
+        pytest.param(  # invalid start type
+            pd.MultiIndex.from_arrays(
+                [
+                    [0.0, 1.0],
+                    pd.to_timedelta([1.0, 2.0], unit='s'),
+                ],
+                names=['start', 'end'],
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+        pytest.param(  # invalid end type
+            pd.MultiIndex.from_arrays(
+                [
+                    pd.to_timedelta([0.0, 1.0], unit='s'),
+                    [1.0, 2.0],
+                ],
+                names=['start', 'end'],
+            ),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_assert_index(obj):
+    audinterface.core.utils.assert_index(obj)
+
+
+@pytest.mark.parametrize(
+    'starts,ends',
+    [
+        (
+            None,
+            None,
+        ),
+        (
+            [],
+            [],
+        ),
+        (
+            pd.Timedelta('0s'),
+            None,
+        ),
+        (
+            pd.Timedelta('0s'),
+            pd.Timedelta('1s'),
+        ),
+        (
+            [pd.Timedelta('0s'), pd.Timedelta('1s')],
+            None,
+        ),
+        (
+            None,
+            [pd.Timedelta('1s'), pd.Timedelta('2s')],
+        ),
+        (
+            [pd.Timedelta('0s'), pd.Timedelta('1s')],
+            [pd.Timedelta('1s'), pd.Timedelta('2s')],
+        ),
+        (
+            pd.timedelta_range('0s', freq='1s', periods=2),
+            pd.timedelta_range('1s', freq='1s', periods=2),
+        ),
+        pytest.param(  # len starts != len ends
+            [pd.Timedelta('0s'), pd.Timedelta('1s')],
+            [pd.Timedelta('1s')],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_create_segmented_index(starts, ends):
+
+    index = audinterface.utils.signal_index(starts=starts, ends=ends)
+
+    starts = to_array(starts)
+    ends = to_array(ends)
+
+    if starts is None and ends is None:
+
+        assert index.get_level_values(
+            audformat.define.IndexField.START
+        ).tolist() == []
+        assert index.get_level_values(
+            audformat.define.IndexField.END
+        ).tolist() == []
+
+    else:
+
+        if starts is not None:
+            assert index.get_level_values(
+                audformat.define.IndexField.START
+            ).tolist() == starts
+        else:
+            assert index.get_level_values(
+                audformat.define.IndexField.START
+            ).tolist() == [pd.Timedelta(0)] * len(ends)
+
+        if ends is not None:
+            assert index.get_level_values(
+                audformat.define.IndexField.END
+            ).tolist() == ends
+        else:
+            assert index.get_level_values(
+                audformat.define.IndexField.END
+            ).tolist() == [pd.NaT] * len(starts)


### PR DESCRIPTION
Closes #14 

Introduces utility function `audinterface.utils.signal_index()`, which creates a segmented index just like  `audformat.segmented_index()` but without the `file` level. It now takes care of using the correct `Timedelta` dtype.

The original example in #14 now fails:

```python
index = pd.MultiIndex.from_arrays(
    [
        [pd.to_timedelta(0)],
        [pd.to_timedelta(pd.NaT)]
    ],
    names=('start', 'end'),
)
process = audinterface.Process(keep_nat=True)
y = process.process_signal_from_index(np.zeros((1, 4)), 1, index)
y.index.get_level_values(1)
```
```
ValueError: Level 'end' must contain values of type 'timedelta64[ns]'.
```

and the fixed example has the correct type:

```python
index = pd.MultiIndex.from_arrays(
    [
        pd.to_timedelta([0]),
        pd.to_timedelta([pd.NaT])
    ],
    names=('start', 'end'),
)
process = audinterface.Process(keep_nat=True)
y = process.process_signal_from_index(np.zeros((1, 4)), 1, index)
y.index.get_level_values(1)
```
```
TimedeltaIndex([NaT], dtype='timedelta64[ns]', name='end', freq=None)
```

and can be simplified to:

```python
index = audinterface.utils.signal_index(0, pd.NaT)
process = audinterface.Process(keep_nat=True)
y = process.process_signal_from_index(np.zeros((1, 4)), 1, index)
y.index.get_level_values(1)
```
```
TimedeltaIndex([NaT], dtype='timedelta64[ns]', name='end', freq=None)
```