### PR TITLE
Raise error if multiple frames are returned but win_dur is not set

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -494,16 +494,20 @@ class Feature:
         features = features.reshape(new_shape).T
 
         if n_time_steps > 1:
+
             if win_dur is None:
-                starts = [start] * n_time_steps
-                ends = [end] * n_time_steps
-            else:
-                starts = pd.timedelta_range(
-                    start,
-                    freq=hop_dur,
-                    periods=n_time_steps,
+                raise RuntimeError(
+                    f"Got "
+                    f"{n_time_steps} "
+                    f"frames, but 'win_dur' is not set."
                 )
-                ends = starts + win_dur
+
+            starts = pd.timedelta_range(
+                start,
+                freq=hop_dur,
+                periods=n_time_steps,
+            )
+            ends = starts + win_dur
         else:
             starts = [start]
             ends = [end]


### PR DESCRIPTION
So far it was possible to not specify a `win_dur` but still return multiple multiple frames. In that case the original `start` and `end` of the processed segment was simply duplicated. However, this creates an index that is not confirm with `audformat`, as discussed in more details here: https://github.com/audeering/audinterface/pull/18#discussion_r664276442

With this PR we now raise a `RuntimeError`:

```python
feature = audinterface.Feature(
    ['f1', 'f2'],
    process_func=lambda x, sr: np.ones((1, 2, 3))  # return 3 frames
)
index = audformat.segmented_index('test.wav')
feature.process_index(index)
```
```
RuntimeError: Got 3 frames, but 'win_dur' is not set.
```