### PR TITLE
Forbid duplicates in signal index

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -362,7 +362,7 @@ class Feature:
             RuntimeError: if channel selection is invalid
             RuntimeError: if multiple frames are returned,
                 but ``win_dur`` is not set
-            ValueError: if given index has wrong format
+            ValueError: if index contains duplicates
 
         """
         series = self.process.process_signal_from_index(

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -198,6 +198,8 @@ class Feature:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            RuntimeError: if multiple frames are returned,
+                but ``win_dur`` is not set
 
         """
         series = self.process.process_file(
@@ -231,6 +233,8 @@ class Feature:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            RuntimeError: if multiple frames are returned,
+                but ``win_dur`` is not set
 
         """
         series = self.process.process_files(
@@ -258,6 +262,8 @@ class Feature:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            RuntimeError: if multiple frames are returned,
+                but ``win_dur`` is not set
 
         """
         files = audeer.list_file_names(root, filetype=filetype)
@@ -279,6 +285,8 @@ class Feature:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            RuntimeError: if multiple frames are returned,
+                but ``win_dur`` is not set
             ValueError: if index is not conform to audformat_
 
         .. _audformat: https://audeering.github.io/audformat/data-format.html
@@ -320,6 +328,8 @@ class Feature:
                 but ``self.win_dur`` is not specified
             RuntimeError: if number of features does not match
                 number of feature names
+            RuntimeError: if multiple frames are returned,
+                but ``win_dur`` is not set
 
         """
         series = self.process.process_signal(
@@ -350,6 +360,8 @@ class Feature:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            RuntimeError: if multiple frames are returned,
+                but ``win_dur`` is not set
             ValueError: if given index has wrong format
 
         """
@@ -379,6 +391,8 @@ class Feature:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            RuntimeError: if multiple frames are returned,
+                but ``win_dur`` is not set
             ValueError: if index is not conform to the `Unified Format`_
 
         .. _`Unified Format`: http://tools.pp.audeering.com/audata/
@@ -543,6 +557,8 @@ class Feature:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            RuntimeError: if multiple frames are returned,
+                but ``win_dur`` is not set
 
         """
         y = self.process(

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -469,6 +469,7 @@ class Process:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            ValueError: if index contains duplicates
 
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
@@ -737,6 +738,7 @@ class ProcessWithContext:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            ValueError: if index contains duplicates
 
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -418,6 +418,7 @@ class Segment:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            ValueError: if index contains duplicates
 
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -16,6 +16,22 @@ def assert_index(obj: pd.Index):
     r"""Check if index is conform to audformat."""
 
     if isinstance(obj, pd.MultiIndex) and len(obj.levels) == 2:
+
+        if obj.has_duplicates:
+            max_display = 10
+            duplicates = obj[obj.duplicated()]
+            msg_tail = '\n...' if len(duplicates) > max_display else ''
+            msg_duplicates = '\n'.join(
+                [
+                    str(duplicate) for duplicate
+                    in duplicates[:max_display].tolist()
+                ]
+            )
+            raise ValueError(
+                'Found duplicates:\n'
+                f'{msg_duplicates}{msg_tail}'
+            )
+
         if not (
                 obj.names[0] == audformat.define.IndexField.START
                 and obj.names[1] == audformat.define.IndexField.END

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -215,10 +215,7 @@ def test_process_file(tmpdir, start, end, segment):
 
 def test_process_folder(tmpdir):
 
-    starts = [0] * 3
-    ends = [1] * 3
-    index = audinterface.utils.signal_index(starts, ends)
-
+    index = audinterface.utils.signal_index(0, 1)
     feature = audinterface.Feature(
         feature_names=('o1', 'o2', 'o3'),
         process_func=feature_extractor,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,6 +84,11 @@ def test_assert_index(obj):
             [pd.Timedelta('1s')],
             marks=pytest.mark.xfail(raises=ValueError),
         ),
+        pytest.param(  # duplicates
+            [pd.Timedelta('0s'), pd.Timedelta('0s')],
+            [pd.Timedelta('1s'), pd.Timedelta('1s')],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
     ]
 )
 def test_create_segmented_index(starts, ends):


### PR DESCRIPTION
As discussed in https://github.com/audeering/audinterface/pull/18#discussion_r664273761 we now also forbid duplicates in indices that hold only `start` and `end` times.

### Example

```python
audinterface.utils.signal_index([0, 0], [1, 1])
```
```
Traceback (most recent call last):
  File "/media/jwagner/Data/Git/pyaudinterface/my/my.py", line 25, in <module>
    audinterface.utils.signal_index([0, 0], [1, 1])
  File "/media/jwagner/Data/Git/pyaudinterface/audinterface/core/utils.py", line 258, in signal_index
    assert_index(index)
  File "/media/jwagner/Data/Git/pyaudinterface/audinterface/core/utils.py", line 31, in assert_index
    'Found duplicates:\n'
ValueError: Found duplicates:
(Timedelta('0 days 00:00:00'), Timedelta('0 days 00:00:01'))
```