### PR TITLE
Support more feature shapes

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -457,7 +457,7 @@ class Feature:
                 f'not {features.ndim}.'
             )
 
-        # reshape features to (channels x features x frames)
+        # figure out channels, feature, frames
         if features.ndim == 1:
             n_channels = 1
             n_features = features.size
@@ -484,8 +484,7 @@ class Feature:
             n_features = features.shape[1]
             n_frames = features.shape[2]
 
-        features = features.reshape([n_channels, n_features, n_frames])
-
+        # assert channels and features have expected length
         if n_channels != self.num_channels:
             raise RuntimeError(
                 f'Number of channels must be'
@@ -501,7 +500,8 @@ class Feature:
                 f'{n_features}.'
             )
 
-        return features
+        # reshape features to (channels,  features, frames)
+        return features.reshape([n_channels, n_features, n_frames])
 
     def _series_to_frame(
             self,

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -560,7 +560,8 @@ class Feature:
         features = self._reshape_3d(features)
         n_channels, n_features, n_frames = features.shape
 
-        # Reshape features and store channel number as first feature
+        # Combine features and channels into one dimension
+        # f1-c1, f2-c1, fN-c1, ..., f1-cM, f2-cM,..., fN-cM
         new_shape = (n_channels * n_features, n_frames)
         features = features.reshape(new_shape).T
 

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -424,6 +424,12 @@ class Feature:
         r"""Reshape to [n_channels, n_features, n_frames]."""
 
         if self.process.process_func_is_mono:
+            for channels_features in features:
+                if not isinstance(channels_features, np.ndarray):
+                    raise RuntimeError(
+                        "Features must be a 'np.ndarray', "
+                        f"not '{type(channels_features)}'."
+                    )
             features = np.array(features)
             # when mono processing is turned on
             # the channel dimension has to be 1

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -433,15 +433,13 @@ class Feature:
             # consider two special cases
             if (features.ndim == 4) and \
                     (features.shape[1] == 1):
-                # (1, features, frames)
-                # -> (channels, 1, features, frames)
+                # (channels, 1, features, frames)
                 # -> (channels, features, frames)
                 features = features.squeeze(axis=1)
             elif (features.ndim == 3) and \
                     (self.win_dur is None) and \
                     (features.shape[1] == 1):
-                # (1, features)
-                # -> (channels, 1, features)
+                # (channels, 1, features)
                 # -> (channels, features)
                 features = features.squeeze(axis=1)
 

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -561,7 +561,7 @@ class Feature:
         n_channels, n_features, n_frames = features.shape
 
         # Combine features and channels into one dimension
-        # f1-c1, f2-c1, fN-c1, ..., f1-cM, f2-cM,..., fN-cM
+        # f1-c1, f2-c1, ..., fN-c1, ..., f1-cM, f2-cM, ..., fN-cM
         new_shape = (n_channels * n_features, n_frames)
         features = features.reshape(new_shape).T
 

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -47,8 +47,10 @@ class Feature:
             and ``sampling_rate``
             and any number of additional keyword arguments.
             The function must return features in the shape of
-            ``(num_channels, num_features)``
-            or ``(num_channels, num_features, num_time_steps)``.
+            ``(num_features),
+            ``(num_channels, num_features)``,
+            ``(num_features, num_frames)``,
+            or ``(num_channels, num_features, num_frames)``.
         process_func_is_mono: apply ``process_func`` to every channel
             individually
         sampling_rate: sampling rate in Hz.
@@ -593,7 +595,8 @@ class Feature:
             sampling_rate: sampling rate in Hz
 
         Returns:
-            Processed signal
+            feature array with shape
+            ``(num_channels, num_features, num_frames)``
 
         Raises:
             RuntimeError: if sampling rates do not match

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -417,7 +417,7 @@ class Feature:
         """
         return frame.values.T.reshape(self.num_channels, self.num_features, -1)
 
-    def _assert_shape_3d(
+    def _reshape_3d(
             self,
             features: typing.Union[np.ndarray, pd.Series]
     ):
@@ -557,12 +557,10 @@ class Feature:
             win_dur = None
             hop_dur = None
 
-        features = self._assert_shape_3d(features)
+        features = self._reshape_3d(features)
         n_channels, n_features, n_frames = features.shape
 
         # Reshape features and store channel number as first feature
-        # [n_channels, n_features, n_time_steps] =>
-        # [n_channels * n_features + 1, n_time_steps]
         new_shape = (n_channels * n_features, n_frames)
         features = features.reshape(new_shape).T
 
@@ -624,4 +622,4 @@ class Feature:
             signal,
             sampling_rate,
         )
-        return self._assert_shape_3d(y)
+        return self._reshape_3d(y)

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -425,9 +425,24 @@ class Feature:
 
         if self.process.process_func_is_mono:
             features = np.array(features)
-            if features.ndim == 4 and features.shape[1] == 1:
-                # mono processing turned on
-                # and process function returns (1, features, frames)
+            # when mono processing is turned on
+            # the channel dimension has to be 1
+            # so we would usually omit it,
+            # but since older versions required
+            # a channel dimension we have to
+            # consider two special cases
+            if (features.ndim == 4) and \
+                    (features.shape[1] == 1):
+                # (1, features, frames)
+                # -> (channels, 1, features, frames)
+                # -> (channels, features, frames)
+                features = features.squeeze(axis=1)
+            elif (features.ndim == 3) and \
+                    (self.win_dur is None) and \
+                    (features.shape[1] == 1):
+                # (1, features)
+                # -> (channels, 1, features)
+                # -> (channels, features)
                 features = features.squeeze(axis=1)
 
         if not isinstance(features, np.ndarray):

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -583,7 +583,7 @@ class Process:
             self.channels,
             self.mixdown,
         )
-        if self.process_func_is_mono and signal.shape[0] > 1:
+        if self.process_func_is_mono:
             return [
                 self.process_func(
                     np.atleast_2d(channel),

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -456,15 +456,25 @@ def test_process_folder(tmpdir):
             True,
             np.ones((5, 2 * 3)),
         ),
-        # Feature extractor function is not a np.ndarray
+        # Feature extractor function returns not a np.ndarray
         pytest.param(
-            lambda s, sr: 1,
+            lambda s, sr: [1, 1, 1],
             3,
             SIGNAL_2D,
             None,
             None,
-            None,
             False,
+            None,
+            marks=pytest.mark.xfail(raises=RuntimeError),
+        ),
+        pytest.param(
+            lambda s, sr: [1, 1, 1],
+            3,
+            SIGNAL_2D,
+            None,
+            None,
+            True,
+            None,
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),
         # Feature extractor function returns too less dimensions

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -402,15 +402,6 @@ def test_process_folder(tmpdir):
             True,
             np.ones((1, 2 * 3)),
         ),
-        # (
-        #     lambda s, sr: np.ones((1, 3)),
-        #     3,
-        #     SIGNAL_2D,
-        #     None,
-        #     None,
-        #     True,
-        #     np.ones((1, 2 * 3)),
-        # ),
         # 2 channels, 3 features, 5 frames + expand
         (
             lambda s, sr: np.ones((3, 5)),

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -69,7 +69,23 @@ def test_feature():
             SIGNAL_1D,
             audinterface.Feature(
                 feature_names=['f1', 'f2', 'f3'],
+                process_func=lambda x, sr: np.ones(3),
+            ),
+            np.ones((1, 3, 1)),
+        ),
+        (
+            SIGNAL_1D,
+            audinterface.Feature(
+                feature_names=['f1', 'f2', 'f3'],
                 process_func=lambda x, sr: np.ones((1, 3)),
+            ),
+            np.ones((1, 3, 1)),
+        ),
+        (
+            SIGNAL_1D,
+            audinterface.Feature(
+                feature_names=['f1', 'f2', 'f3'],
+                process_func=lambda x, sr: np.ones((3, 1)),
             ),
             np.ones((1, 3, 1)),
         ),
@@ -122,6 +138,16 @@ def test_feature():
             SIGNAL_2D,
             audinterface.Feature(
                 feature_names=['f1', 'f2', 'f3'],
+                process_func=lambda x, sr: np.ones((1, 3)),
+                channels=range(2),
+                process_func_is_mono=True,
+            ),
+            np.ones((2, 3, 1)),
+        ),
+        (
+            SIGNAL_2D,
+            audinterface.Feature(
+                feature_names=['f1', 'f2', 'f3'],
                 process_func=lambda x, sr: np.ones((1, 3, 1)),
                 channels=range(2),
                 process_func_is_mono=True,
@@ -150,7 +176,7 @@ def test_feature():
         ),
     ]
 )
-def test_process_callable(signal, feature, expected):
+def test_process_call(signal, feature, expected):
     np.testing.assert_array_equal(
         feature(signal, SAMPLING_RATE),
         expected,
@@ -354,7 +380,7 @@ def test_process_folder(tmpdir):
             False,
             np.ones((5, 2 * 3)),
         ),
-        # 1 channel, 1 feature + expand
+        # 1 channel, 1 feature + mono processing
         (
             lambda s, sr: np.ones(1),
             1,
@@ -373,7 +399,7 @@ def test_process_folder(tmpdir):
             True,
             np.ones((1, 1)),
         ),
-        # 2 channels, 1 feature + expand
+        # 2 channels, 1 feature + mono processing
         (
             lambda s, sr: np.ones(1),
             1,
@@ -392,7 +418,7 @@ def test_process_folder(tmpdir):
             True,
             np.ones((1, 2)),
         ),
-        # 2 channels, 3 features + expand
+        # 2 channels, 3 features + mono processing
         (
             lambda s, sr: np.ones(3),
             3,
@@ -402,7 +428,16 @@ def test_process_folder(tmpdir):
             True,
             np.ones((1, 2 * 3)),
         ),
-        # 2 channels, 3 features, 5 frames + expand
+        (
+            lambda s, sr: np.ones((1, 3, 1)),
+            3,
+            SIGNAL_2D,
+            None,
+            None,
+            True,
+            np.ones((1, 2 * 3)),
+        ),
+        # 2 channels, 3 features, 5 frames + mono processing
         (
             lambda s, sr: np.ones((3, 5)),
             3,
@@ -434,7 +469,7 @@ def test_process_folder(tmpdir):
         ),
         # Feature extractor function returns too less dimensions
         pytest.param(
-            lambda s, sr: np.ones((1, )),
+            lambda s, sr: np.ones(1),
             3,
             SIGNAL_2D,
             None,


### PR DESCRIPTION
As discussed in #21 it would be nice to be less strict on the returned shape of the process function that can be used with `Feature`. Especially since we already support 2d, but in that case the first dimension always has to be the channels, which does not always make sense, e.g. with `process_func_is_mono=True` we already know that the channel dimension will be 1.

Luckily, since `channels` and `features` are fixed and only `frames` can vary, we can derive the correct 3d shape from 1 or 2 dimensions. In this PR we add support for:

* `(features)`
* `(features, frames)`

in addition to:

* `(channels, features)`
* `(channels, features, frames)`

## Bug fix

While implementing this PR I realized that `__call__()` did not return `(channels, features, frames)` as promised, but the original shape from the processing function (which does not make sense, cause if that is the intension of the user she should use `Process`). This is now fixed (we probably didn't find the bug yet, because we seldomly use `__call__()` but rather one of the process functions, which were not affected).

## Examples:

### Single frame on mono file

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random(2),
)
```

or

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((1, 2)),
)
```

or

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((2, 1)),
)
```

or

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((1, 2, 1)),
)
```

return:

```python
feature.process_file('mono.wav')
```
```
                                                  x         y
file     start  end                                          
mono.wav 0 days 0 days 00:00:07.247709751  0.017839  0.185667
```

### Single frame on stereo file

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((2, 2)),
    channels=[0, 1],
)
```

or

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((2, 2, 1)),
    channels=[0, 1],
)
```

or

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random(2),
    channels=[0, 1],
    process_func_is_mono=True,
)
```

or

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((1, 2)),
    channels=[0, 1],
    process_func_is_mono=True,
)
```

or

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((2, 1)),
    channels=[0, 1],
    process_func_is_mono=True,
)
```

or

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((1, 2, 1)),
    channels=[0, 1],
    process_func_is_mono=True,
)
```

return:

```python
feature.process_file('stereo.wav')
```
```
                                                  x-0       y-0       x-1       y-1
file       start  end                                                              
stereo.wav 0 days 0 days 00:00:07.247709751  0.353643  0.968675  0.304591  0.965526
```

### Multiple frames on mono file

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((2, 3)),
    win_dur=1.0,
)
```

or 

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((1, 2, 3)),
    win_dur=1.0,
)
```

return

```python
feature.process_file('mono.wav')
```
```
                                                               x         y
file     start                  end                                       
mono.wav 0 days 00:00:00        0 days 00:00:01         0.594710  0.465447
         0 days 00:00:00.500000 0 days 00:00:01.500000  0.800685  0.865276
         0 days 00:00:01        0 days 00:00:02         0.574075  0.012008
```

### Multiple frames on stereo file

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((2, 2, 3)),
    channels=[0, 1],
    win_dur=1.0,
)
```

or 

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((2, 3)),
    channels=[0, 1],
    process_func_is_mono=True,
    win_dur=1.0,
)
```

or 

```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: np.random.random((1, 2, 3)),
    channels=[0, 1],
    process_func_is_mono=True,
    win_dur=1.0,
)
```

return:

```python
feature.process_file('stereo.wav')
```
```
                                                               x-0       y-0       x-1       y-1
file       start                  end                                                           
stereo.wav 0 days 00:00:00        0 days 00:00:01         0.216335  0.201805  0.907083  0.913285
           0 days 00:00:00.500000 0 days 00:00:01.500000  0.078636  0.977286  0.682514  0.933484
           0 days 00:00:01        0 days 00:00:02         0.245939  0.684865  0.169649  0.852454
```
