### PR TITLE
Feature: support scalars and lists

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -94,7 +94,7 @@ class Feature:
             *,
             name: str = None,
             params: typing.Dict = None,
-            process_func: typing.Callable[..., np.ndarray] = None,
+            process_func: typing.Callable[..., typing.Any] = None,
             process_func_is_mono: bool = False,
             sampling_rate: int = None,
             win_dur: typing.Union[int, float] = None,
@@ -423,14 +423,10 @@ class Feature:
     ):
         r"""Reshape to [n_channels, n_features, n_frames]."""
 
+        features = np.array(features)
+        features = np.atleast_1d(features)
+
         if self.process.process_func_is_mono:
-            for channels_features in features:
-                if not isinstance(channels_features, np.ndarray):
-                    raise RuntimeError(
-                        "Features must be a 'np.ndarray', "
-                        f"not '{type(channels_features)}'."
-                    )
-            features = np.array(features)
             # when mono processing is turned on
             # the channel dimension has to be 1
             # so we would usually omit it,
@@ -448,12 +444,6 @@ class Feature:
                 # (channels, 1, features)
                 # -> (channels, features)
                 features = features.squeeze(axis=1)
-
-        if not isinstance(features, np.ndarray):
-            raise RuntimeError(
-                "Features must be a 'np.ndarray', "
-                f"not '{type(features)}'."
-            )
 
         if features.ndim > 3:
             raise RuntimeError(

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -302,6 +302,24 @@ def test_process_folder(tmpdir):
         ),
         # 1 channel, 1 feature
         (
+            lambda s, sr: 1,
+            1,
+            SIGNAL_1D,
+            None,
+            None,
+            False,
+            np.ones((1, 1)),
+        ),
+        (
+            lambda s, sr: 'f',
+            1,
+            SIGNAL_1D,
+            None,
+            None,
+            False,
+            np.array([['f']]),
+        ),
+        (
             lambda s, sr: np.ones(1),
             1,
             SIGNAL_1D,
@@ -311,6 +329,24 @@ def test_process_folder(tmpdir):
             np.ones((1, 1)),
         ),
         # 1 channel, 1 feature
+        (
+            lambda s, sr: [1],
+            1,
+            SIGNAL_1D,
+            None,
+            None,
+            False,
+            np.ones((1, 1)),
+        ),
+        (
+            lambda s, sr: ['f'],
+            1,
+            SIGNAL_1D,
+            None,
+            None,
+            False,
+            np.array([['f']]),
+        ),
         (
             lambda s, sr: np.ones((1, 1)),
             1,
@@ -322,6 +358,24 @@ def test_process_folder(tmpdir):
         ),
         # 1 channel, 3 features
         (
+            lambda s, sr: [1, 1, 1],
+            3,
+            SIGNAL_1D,
+            None,
+            None,
+            False,
+            np.ones((1, 3)),
+        ),
+        (
+            lambda s, sr: ['a', 1, 1.0],
+            3,
+            SIGNAL_1D,
+            None,
+            None,
+            False,
+            np.array([['a', 1, 1.0]]),
+        ),
+        (
             lambda s, sr: np.ones(3),
             3,
             SIGNAL_1D,
@@ -331,6 +385,24 @@ def test_process_folder(tmpdir):
             np.ones((1, 3)),
         ),
         # 1 channel, 3 features
+        (
+            lambda s, sr: [[1, 1, 1]],
+            3,
+            SIGNAL_1D,
+            None,
+            None,
+            False,
+            np.ones((1, 3)),
+        ),
+        (
+            lambda s, sr: [['a', 1, 1.0]],
+            3,
+            SIGNAL_1D,
+            None,
+            None,
+            False,
+            np.array([['a', 1, 1.0]]),
+        ),
         (
             lambda s, sr: np.ones((1, 3)),
             3,
@@ -342,6 +414,24 @@ def test_process_folder(tmpdir):
         ),
         # 2 channels, 1 feature
         (
+            lambda s, sr: [[1], [1]],
+            1,
+            SIGNAL_2D,
+            None,
+            None,
+            False,
+            np.ones((1, 2)),
+        ),
+        (
+            lambda s, sr: [['a'], ['b']],
+            1,
+            SIGNAL_2D,
+            None,
+            None,
+            False,
+            np.array([['a', 'b']]),
+        ),
+        (
             lambda s, sr: np.ones((2, 1)),
             1,
             SIGNAL_2D,
@@ -351,6 +441,27 @@ def test_process_folder(tmpdir):
             np.ones((1, 2)),
         ),
         # 2 channels, 3 features
+        (
+            lambda s, sr: [[1, 1, 1], [1, 1, 1]],
+            3,
+            SIGNAL_2D,
+            None,
+            None,
+            False,
+            np.ones((1, 2 * 3)),
+        ),
+        (
+            lambda s, sr: [
+                ['a', 1, 1.0],
+                ['b', 2, 2.0],
+            ],
+            3,
+            SIGNAL_2D,
+            None,
+            None,
+            False,
+            np.array([['a', 1, 1.0, 'b', 2, 2.0]]),
+        ),
         (
             lambda s, sr: np.ones((2, 3)),
             3,
@@ -372,6 +483,15 @@ def test_process_folder(tmpdir):
         ),
         # 2 channels, 3 features, 5 frames
         (
+            lambda s, sr: [[[1] * 5] * 3] * 2,
+            3,
+            SIGNAL_2D,
+            None,
+            None,
+            False,
+            np.ones((5, 2 * 3)),
+        ),
+        (
             lambda s, sr: np.ones((2, 3, 5)),
             3,
             SIGNAL_2D,
@@ -381,6 +501,15 @@ def test_process_folder(tmpdir):
             np.ones((5, 2 * 3)),
         ),
         # 1 channel, 1 feature + mono processing
+        (
+            lambda s, sr: 1,
+            1,
+            SIGNAL_1D,
+            None,
+            None,
+            True,
+            np.ones((1, 1)),
+        ),
         (
             lambda s, sr: np.ones(1),
             1,
@@ -401,6 +530,15 @@ def test_process_folder(tmpdir):
         ),
         # 2 channels, 1 feature + mono processing
         (
+            lambda s, sr: [1],
+            1,
+            SIGNAL_2D,
+            None,
+            None,
+            True,
+            np.ones((1, 2)),
+        ),
+        (
             lambda s, sr: np.ones(1),
             1,
             SIGNAL_2D,
@@ -419,6 +557,15 @@ def test_process_folder(tmpdir):
             np.ones((1, 2)),
         ),
         # 2 channels, 3 features + mono processing
+        (
+            lambda s, sr: [1, 1, 1],
+            3,
+            SIGNAL_2D,
+            None,
+            None,
+            True,
+            np.ones((1, 2 * 3)),
+        ),
         (
             lambda s, sr: np.ones(3),
             3,
@@ -439,6 +586,19 @@ def test_process_folder(tmpdir):
         ),
         # 2 channels, 3 features, 5 frames + mono processing
         (
+            lambda s, sr: [
+                [1, 1, 1, 1, 1],
+                [1, 1, 1, 1, 1],
+                [1, 1, 1, 1, 1],
+            ],
+            3,
+            SIGNAL_2D,
+            None,
+            None,
+            True,
+            np.ones((5, 2 * 3)),
+        ),
+        (
             lambda s, sr: np.ones((3, 5)),
             3,
             SIGNAL_2D,
@@ -455,27 +615,6 @@ def test_process_folder(tmpdir):
             None,
             True,
             np.ones((5, 2 * 3)),
-        ),
-        # Feature extractor function returns not a np.ndarray
-        pytest.param(
-            lambda s, sr: [1, 1, 1],
-            3,
-            SIGNAL_2D,
-            None,
-            None,
-            False,
-            None,
-            marks=pytest.mark.xfail(raises=RuntimeError),
-        ),
-        pytest.param(
-            lambda s, sr: [1, 1, 1],
-            3,
-            SIGNAL_2D,
-            None,
-            None,
-            True,
-            None,
-            marks=pytest.mark.xfail(raises=RuntimeError),
         ),
         # Feature extractor function returns too less dimensions
         pytest.param(

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -311,15 +311,6 @@ def test_process_folder(tmpdir):
             np.ones((1, 1)),
         ),
         (
-            lambda s, sr: 'f',
-            1,
-            SIGNAL_1D,
-            None,
-            None,
-            False,
-            np.array([['f']]),
-        ),
-        (
             lambda s, sr: np.ones(1),
             1,
             SIGNAL_1D,
@@ -337,15 +328,6 @@ def test_process_folder(tmpdir):
             None,
             False,
             np.ones((1, 1)),
-        ),
-        (
-            lambda s, sr: ['f'],
-            1,
-            SIGNAL_1D,
-            None,
-            None,
-            False,
-            np.array([['f']]),
         ),
         (
             lambda s, sr: np.ones((1, 1)),
@@ -367,15 +349,6 @@ def test_process_folder(tmpdir):
             np.ones((1, 3)),
         ),
         (
-            lambda s, sr: ['a', 1, 1.0],
-            3,
-            SIGNAL_1D,
-            None,
-            None,
-            False,
-            np.array([['a', 1, 1.0]]),
-        ),
-        (
             lambda s, sr: np.ones(3),
             3,
             SIGNAL_1D,
@@ -393,15 +366,6 @@ def test_process_folder(tmpdir):
             None,
             False,
             np.ones((1, 3)),
-        ),
-        (
-            lambda s, sr: [['a', 1, 1.0]],
-            3,
-            SIGNAL_1D,
-            None,
-            None,
-            False,
-            np.array([['a', 1, 1.0]]),
         ),
         (
             lambda s, sr: np.ones((1, 3)),
@@ -423,15 +387,6 @@ def test_process_folder(tmpdir):
             np.ones((1, 2)),
         ),
         (
-            lambda s, sr: [['a'], ['b']],
-            1,
-            SIGNAL_2D,
-            None,
-            None,
-            False,
-            np.array([['a', 'b']]),
-        ),
-        (
             lambda s, sr: np.ones((2, 1)),
             1,
             SIGNAL_2D,
@@ -449,18 +404,6 @@ def test_process_folder(tmpdir):
             None,
             False,
             np.ones((1, 2 * 3)),
-        ),
-        (
-            lambda s, sr: [
-                ['a', 1, 1.0],
-                ['b', 2, 2.0],
-            ],
-            3,
-            SIGNAL_2D,
-            None,
-            None,
-            False,
-            np.array([['a', 1, 1.0, 'b', 2, 2.0]]),
         ),
         (
             lambda s, sr: np.ones((2, 3)),


### PR DESCRIPTION
Closes #21

Add support for to scalars and lists to `Feature`.


### Examples

```python
feature = audinterface.Feature(
    ['x'],
    process_func=lambda x, sr: 1,
)
feature.process_file('mono.wav')
```
```
                                           x
file     start  end                         
mono.wav 0 days 0 days 00:00:07.247709751  1
```
```python
feature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: [1, 2],
)
 feature.process_file('mono.wav')
```
```
                                           x  y
file     start  end                            
mono.wav 0 days 0 days 00:00:07.247709751  1  2
```
```pythonfeature = audinterface.Feature(
    ['x', 'y'],
    process_func=lambda x, sr: [[1, 1, 1], [2, 2, 2]],
    win_dur=1.0,
)
feature.process_file('mono.wav')
```
```
                                                        x  y
file     start                  end                         
mono.wav 0 days 00:00:00        0 days 00:00:01         1  2
         0 days 00:00:00.500000 0 days 00:00:01.500000  1  2
         0 days 00:00:01        0 days 00:00:02         1  2
```


