### PR TITLE
DOC: fix typo in Feature docstring

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -47,7 +47,7 @@ class Feature:
             and ``sampling_rate``
             and any number of additional keyword arguments.
             The function must return features in the shape of
-            ``(num_features),
+            ``(num_features)``,
             ``(num_channels, num_features)``,
             ``(num_features, num_frames)``,
             or ``(num_channels, num_features, num_frames)``.


### PR DESCRIPTION
Changes

![image](https://user-images.githubusercontent.com/173624/126753586-495e73de-f0e3-4458-8084-b5f331ff3bc0.png)


to

![image](https://user-images.githubusercontent.com/173624/126752741-01516a46-fd4d-40c0-b149-b002ea18b1c8.png)
