### PR TITLE
Update Python package metadata syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [metadata]
 name = audinterface
 author = Johannes Wagner, Hagen Wierstorf, Andreas Triantafyllopoulos
-author-email = jwagner@audeering.com, hwierstorf@audeering.com, atriant@audeering.com
+author_email = jwagner@audeering.com, hwierstorf@audeering.com, atriant@audeering.com
 url = https://github.com/audeering/audinterface/
-project-urls =
+project_urls =
     Documentation = https://audeering.github.io/audinterface/
 description = Generic interfaces for signal processing
-long-description = file: README.rst, CHANGELOG.rst
+long_description = file: README.rst, CHANGELOG.rst
 license = MIT
-license-file = LICENSE
+license_file = LICENSE
 keywords = dsp, audio, machine learning
 platforms= any
 classifiers =


### PR DESCRIPTION
Replace deprecated `abc-def` entries with `abc_def` in `setup.cfg`.