### PR TITLE
Avoid pandas warnings

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -137,7 +137,7 @@ class Feature:
             def process_func(signal, _):
                 return np.zeros(
                     (num_channels, len(feature_names)),
-                    dtype=np.float,
+                    dtype=float,
                 )
 
         if mixdown or isinstance(channels, int):

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -721,7 +721,13 @@ class ProcessWithContext:
         )
         y = self(signal, sampling_rate, starts_i, ends_i)
 
-        return pd.Series(y, index=index)
+        # For an empty Series we force the dtype
+        if len(y) == 0:
+            y = pd.Series(y, index=index, dtype='float64')
+        else:
+            y = pd.Series(y, index=index)
+
+        return y
 
     def __call__(
         self,


### PR DESCRIPTION
This adjusts the code to avoid the following warnings

![image](https://user-images.githubusercontent.com/173624/148033043-95b94ee0-1b2d-4f38-8e89-905a79938459.png)

as can be seen in https://github.com/audeering/audinterface/runs/4699571292?check_suite_focus=true