### PR TITLE
Release 0.8.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 0.8.0 (2022-01-04)
+--------------------------
+
+* Added: Python 3.9 support
+* Added: ``process_func_args`` argument to process methods
+* Deprecated: ``**kwargs`` in process methods,
+  use ``process_func_args`` argument instead
+* Removed: deprecated ``process_unified_format_index()`` methods
+* Removed: Python 3.6 support
+
+
 Version 0.7.0 (2021-07-23)
 --------------------------
 


### PR DESCRIPTION
Before doing a 1.0.0 release we need to do a 0.8.0 release in between as we have marked stuff as deprecated and to be removed with 1.0.0 (https://github.com/audeering/audinterface/pull/28), and we have removed stuff that was marked to be removed in 0.8.0 (https://github.com/audeering/audinterface/pull/29).