### PR TITLE
Process_folder(): handle empty and non-existing folder

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -497,6 +497,7 @@ class Feature:
         if series.empty:
             return pd.DataFrame(
                 columns=self.column_names,
+                dtype=float,
             )
 
         frames = [None] * len(series)

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import typing
 import warnings
@@ -274,12 +275,21 @@ class Feature:
             filetype: file extension
 
         Raises:
+            FileNotFoundError: if folder does not exist
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
             RuntimeError: if multiple frames are returned,
                 but ``win_dur`` is not set
 
         """
+        root = audeer.safe_path(root)
+        if not os.path.exists(root):
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                root,
+            )
+
         files = audeer.list_file_names(root, filetype=filetype)
         files = [os.path.join(root, os.path.basename(f)) for f in files]
         return self.process_files(files)

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -138,7 +138,7 @@ class Feature:
             def process_func(signal, _):
                 return np.zeros(
                     (num_channels, len(feature_names)),
-                    dtype=float,
+                    dtype=object,
                 )
 
         if mixdown or isinstance(channels, int):
@@ -497,7 +497,7 @@ class Feature:
         if series.empty:
             return pd.DataFrame(
                 columns=self.column_names,
-                dtype=float,
+                dtype=object,
             )
 
         frames = [None] * len(series)

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -267,6 +267,7 @@ class Process:
             Series with processed files conform to audformat_
 
         Raises:
+            FileNotFoundError: if folder does not exist
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
 

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import typing
 import warnings
@@ -214,6 +215,9 @@ class Process:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
+        if len(files) == 0:
+            return pd.Series(dtype=float)
+
         if isinstance(starts, (type(None), float, int, str, pd.Timedelta)):
             starts = [starts] * len(files)
         if isinstance(ends, (type(None), float, int, str, pd.Timedelta)):
@@ -269,6 +273,14 @@ class Process:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
+        root = audeer.safe_path(root)
+        if not os.path.exists(root):
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                root,
+            )
+
         files = audeer.list_file_names(root, filetype=filetype)
         files = [os.path.join(root, os.path.basename(f)) for f in files]
         return self.process_files(files)

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -216,7 +216,7 @@ class Process:
 
         """
         if len(files) == 0:
-            return pd.Series(dtype=float)
+            return pd.Series(dtype=object)
 
         if isinstance(starts, (type(None), float, int, str, pd.Timedelta)):
             starts = [starts] * len(files)
@@ -293,7 +293,7 @@ class Process:
     ) -> pd.Series:
         r"""Like process_index, but does not apply segmentation."""
         if index.empty:
-            return pd.Series(None, index=index, dtype=float)
+            return pd.Series(None, index=index, dtype=object)
 
         params = [
             (
@@ -445,7 +445,7 @@ class Process:
         r"""Like process_signal_from_index, but does not apply segmentation."""
 
         if index.empty:
-            return pd.Series(None, index=index, dtype=float)
+            return pd.Series(None, index=index, dtype=object)
 
         if isinstance(index, pd.MultiIndex) and len(index.levels) == 2:
             params = [
@@ -505,7 +505,7 @@ class Process:
         utils.assert_index(index)
 
         if index.empty:
-            return pd.Series(None, index=index, dtype=float)
+            return pd.Series(None, index=index, dtype=object)
 
         if self.segment is not None:
             index = self.segment.process_signal_from_index(
@@ -675,7 +675,7 @@ class ProcessWithContext:
         index = audformat.utils.to_segmented_index(index)
 
         if index.empty:
-            return pd.Series(index=index, dtype=float)
+            return pd.Series(index=index, dtype=object)
 
         files = index.levels[0]
         ys = [None] * len(files)
@@ -736,7 +736,7 @@ class ProcessWithContext:
 
         # For an empty Series we force the dtype
         if len(y) == 0:
-            y = pd.Series(y, index=index, dtype='float64')
+            y = pd.Series(y, index=index, dtype=object)
         else:
             y = pd.Series(y, index=index)
 

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import typing
 import warnings
@@ -299,12 +300,21 @@ class Segment:
             Segmented index conform to audformat_
 
         Raises:
+            FileNotFoundError: if folder does not exist
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
 
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
+        root = audeer.safe_path(root)
+        if not os.path.exists(root):
+            raise FileNotFoundError(
+                errno.ENOENT,
+                os.strerror(errno.ENOENT),
+                root,
+            )
+
         files = audeer.list_file_names(root, filetype=filetype)
         files = [os.path.join(root, os.path.basename(f)) for f in files]
         return self.process_files(files)

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -293,9 +293,9 @@ def test_process_folder(tmpdir):
 
     # empty folder
     root = str(tmpdir.mkdir('empty'))
-    y = feature.process_folder(root)
+    df = feature.process_folder(root)
     pd.testing.assert_frame_equal(
-        y,
+        df,
         pd.DataFrame(
             dtype=float,
             columns=feature.column_names,

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -297,7 +297,7 @@ def test_process_folder(tmpdir):
     pd.testing.assert_frame_equal(
         y,
         pd.DataFrame(
-            dtype=object,
+            dtype=float,
             columns=feature.column_names,
         ),
     )

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -262,8 +262,9 @@ def test_process_file(tmpdir, start, end, segment):
 def test_process_folder(tmpdir):
 
     index = audinterface.utils.signal_index(0, 1)
+    feature_names = ['o1', 'o2', 'o3']
     feature = audinterface.Feature(
-        feature_names=('o1', 'o2', 'o3'),
+        feature_names,
         process_func=feature_extractor,
         sampling_rate=None,
         channels=range(NUM_CHANNELS),
@@ -285,6 +286,21 @@ def test_process_folder(tmpdir):
     assert all(y.index.levels[1] == index.levels[0])
     assert all(y.index.levels[2] == index.levels[1])
     np.testing.assert_array_equal(y.values, y_expected)
+
+    # non-existing folder
+    with pytest.raises(FileNotFoundError):
+        feature.process_folder('bad-folder')
+
+    # empty folder
+    root = str(tmpdir.mkdir('empty'))
+    y = feature.process_folder(root)
+    pd.testing.assert_frame_equal(
+        y,
+        pd.DataFrame(
+            dtype=object,
+            columns=feature.column_names,
+        ),
+    )
 
 
 def test_process_func_args():

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -297,7 +297,7 @@ def test_process_folder(tmpdir):
     pd.testing.assert_frame_equal(
         df,
         pd.DataFrame(
-            dtype=float,
+            dtype=object,
             columns=feature.column_names,
         ),
     )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -496,18 +496,27 @@ def test_process_folder(
         verbose=False,
     )
     sampling_rate = 8000
-    path = str(tmpdir.mkdir('wav'))
+    root = str(tmpdir.mkdir('wav'))
     files = [
-        os.path.join(path, f'file{n}.wav') for n in range(num_files)
+        os.path.join(root, f'file{n}.wav') for n in range(num_files)
     ]
     for file in files:
         signal = np.random.uniform(-1.0, 1.0, (1, sampling_rate))
         af.write(file, signal, sampling_rate)
-    y = process.process_folder(path)
+    y = process.process_folder(root)
     pd.testing.assert_series_equal(
         y,
         process.process_files(files),
     )
+
+    # non-existing folder
+    with pytest.raises(FileNotFoundError):
+        process.process_folder('bad-folder')
+
+    # empty folder
+    root = str(tmpdir.mkdir('empty'))
+    y = process.process_folder(root)
+    pd.testing.assert_series_equal(y, pd.Series(dtype=float))
 
 
 def test_process_func_args():

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -516,7 +516,7 @@ def test_process_folder(
     # empty folder
     root = str(tmpdir.mkdir('empty'))
     y = process.process_folder(root)
-    pd.testing.assert_series_equal(y, pd.Series(dtype=float))
+    pd.testing.assert_series_equal(y, pd.Series(dtype=object))
 
 
 def test_process_func_args():
@@ -1009,7 +1009,7 @@ def test_process_signal_from_index(
     if not expected:
         pd.testing.assert_series_equal(
             result,
-            pd.Series([], index, dtype=float),
+            pd.Series([], index, dtype=object),
         )
     else:
         pd.testing.assert_series_equal(

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -201,7 +201,7 @@ def test_process_signal_from_index(
     if not expected:
         pd.testing.assert_series_equal(
             result,
-            pd.Series([], index, dtype=float),
+            pd.Series([], index, dtype=object),
         )
     else:
         pd.testing.assert_series_equal(

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -86,7 +86,7 @@ def test_file(tmpdir):
     ]
 )
 def test_folder(tmpdir, num_workers, multiprocessing):
-    model = audinterface.Segment(
+    segment = audinterface.Segment(
         process_func=lambda s, sr: INDEX,
         sampling_rate=None,
         resample=False,
@@ -99,10 +99,19 @@ def test_folder(tmpdir, num_workers, multiprocessing):
         os.path.join(path, f'file{n}.wav') for n in range(3)]
     for file in files:
         af.write(file, SIGNAL, SAMPLING_RATE)
-    result = model.process_folder(path)
+    result = segment.process_folder(path)
     assert all(result.levels[0] == files)
     assert all(result.levels[1] == INDEX.levels[0])
     assert all(result.levels[2] == INDEX.levels[1])
+
+    # non-existing folder
+    with pytest.raises(FileNotFoundError):
+        segment.process_folder('bad-folder')
+
+    # empty folder
+    root = str(tmpdir.mkdir('empty'))
+    y = segment.process_folder(root)
+    pd.testing.assert_index_equal(y, audformat.filewise_index())
 
 
 @pytest.mark.parametrize(

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -110,8 +110,8 @@ def test_folder(tmpdir, num_workers, multiprocessing):
 
     # empty folder
     root = str(tmpdir.mkdir('empty'))
-    y = segment.process_folder(root)
-    pd.testing.assert_index_equal(y, audformat.filewise_index())
+    index = segment.process_folder(root)
+    pd.testing.assert_index_equal(index, audformat.filewise_index())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #35 

If a folder is empty or does not exist, `process_folder()` currently raises a `ValueError: All objects passed were None`.

This changes the behavior of `process_folder()` to:

* Raise `FileNotFoundError` if folder does not exist. 
* Return an empty series/frame if folder is empty.

Other change: when an empty series or frame is returned, the data type is set to `object`.