### PR TITLE
Feature: support plain string for single feature

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -93,7 +93,7 @@ class Feature:
     """
     def __init__(
             self,
-            feature_names: typing.Sequence[str],
+            feature_names: typing.Union[str, typing.Sequence[str]],
             *,
             name: str = None,
             params: typing.Dict = None,
@@ -114,6 +114,8 @@ class Feature:
             verbose: bool = False,
             **kwargs,
     ):
+        feature_names = audeer.to_list(feature_names)
+
         process_func_args = process_func_args or {}
         if kwargs:
             warnings.warn(

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -68,6 +68,22 @@ def test_feature():
         (
             SIGNAL_1D,
             audinterface.Feature(
+                feature_names='feature',
+                process_func=lambda x, sr: 1,
+            ),
+            np.ones((1, 1, 1)),
+        ),
+        (
+            SIGNAL_1D,
+            audinterface.Feature(
+                feature_names=['feature'],
+                process_func=lambda x, sr: 1,
+            ),
+            np.ones((1, 1, 1)),
+        ),
+        (
+            SIGNAL_1D,
+            audinterface.Feature(
                 feature_names=['f1', 'f2', 'f3'],
                 process_func=lambda x, sr: np.ones(3),
             ),


### PR DESCRIPTION
If a single string is passed to `Feature' it will be automatically converted to an array.