### PR TITLE
Depend on audresample>=1.1.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ classifiers =
 packages = find:
 install_requires =
     audformat >=0.10.1,<2.0.0
-    audresample >=0.1.6,<0.3.0
+    audresample >=1.1.0,<2.0.0
 setup_requires =
     setuptools_scm
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -200,6 +200,38 @@ def test_process_call(signal, feature, expected):
 
 
 @pytest.mark.parametrize(
+    'signal, extractor',
+    [
+        (
+            np.random.randn(1, SAMPLING_RATE),
+            audinterface.Feature(
+                feature_names='mean',
+                process_func=lambda x, sr: np.mean(x, axis=1),
+            ),
+        ),
+        (
+            np.random.randn(2, SAMPLING_RATE),
+            audinterface.Feature(
+                feature_names='mean',
+                process_func=lambda x, sr: np.mean(x, axis=1),
+            ),
+        ),
+        (
+            np.random.randn(2, SAMPLING_RATE),
+            audinterface.Feature(
+                feature_names='mean',
+                process_func=lambda x, sr: np.mean(x, axis=1),
+                channels=0,
+            ),
+        ),
+    ]
+)
+def test_process_call_datatype(signal, extractor):
+    features = extractor(signal, SAMPLING_RATE)
+    assert signal.dtype == features.dtype
+
+
+@pytest.mark.parametrize(
     'start, end, segment',
     [
         (None, None, None),

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1173,5 +1173,5 @@ def test_sampling_rate_mismatch(
         resample=resample,
         verbose=False,
     )
-    signal = np.array([1., 2., 3.])
+    signal = np.array([1., 2., 3.]).astype('float32')
     process.process_signal(signal, signal_sampling_rate)

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -258,7 +258,7 @@ def test_sampling_rate_mismatch(
         resample=resample,
         verbose=False,
     )
-    signal = np.random.random(5 * 44100)
+    signal = np.random.random(5 * 44100).astype('float32')
     index = audinterface.utils.signal_index(
         pd.timedelta_range('0s', '3s', 3),
         pd.timedelta_range('1s', '4s', 3),


### PR DESCRIPTION
Closes #37 

I added an additional test that checks that the datatype of features stays the same as the datatype of the signal, when the feature extraction function that is used is independent of the datatype (e.g. does not convert everything to `int`).

In addition, I had to fix two tests that were using `audresample.resample()` with float64 signals as inputs.