### PR TITLE
Add cache option to Feature.process_index()

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -301,12 +301,16 @@ class Feature:
             index: pd.Index,
             *,
             root: str = None,
+            cache_root: str = None,
     ) -> pd.DataFrame:
         r"""Extract features from an index conform to audformat_.
 
         Args:
             index: index with segment information
             root: root folder to expand relative file paths
+            cache_root: cache result under this folder.
+                Filename is created with
+                :func:`audformat.utils.hash`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -314,12 +318,41 @@ class Feature:
             RuntimeError: if multiple frames are returned,
                 but ``win_dur`` is not set
             ValueError: if index is not conform to audformat_
+            ValueError: if cached file has different column names
 
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        series = self.process.process_index(index, root=root)
-        return self._series_to_frame(series)
+        cache_path = None
+
+        if cache_root is not None:
+            cache_root = audeer.mkdir(cache_root)
+            hash = audformat.utils.hash(index)
+            cache_path = os.path.join(cache_root, f'{hash}.pkl')
+
+        if cache_path and os.path.exists(cache_path):
+
+            df = pd.read_pickle(cache_path)
+            if list(df.columns) != self.column_names:
+                raise ValueError(
+                    f'Found cached file with different column names: '
+                    f'{list(df.columns)} '
+                    f'!= '
+                    f'{self.column_names}'
+                )
+
+        else:
+
+            y = self.process.process_index(
+                index,
+                root=root,
+            )
+            df = self._series_to_frame(y)
+
+            if cache_path is not None:
+                df.to_pickle(cache_path, protocol=4)
+
+        return df
 
     def process_signal(
             self,

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -309,7 +309,7 @@ class Feature:
             index: index with segment information
             root: root folder to expand relative file paths
             cache_root: cache result under this folder.
-                Filename is created with
+                Filename will be created with
                 :func:`audformat.utils.hash`
 
         Raises:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,15 +19,15 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7 
-    Programming Language :: Python :: 3.8 
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
 
 [options]
 packages = find:
 install_requires =
-    audformat >=0.10.1,<2.0.0
+    audformat >=0.12.1,<2.0.0
     audresample >=1.1.0,<2.0.0
 setup_requires =
     setuptools_scm


### PR DESCRIPTION
Closes #42 

![image](https://user-images.githubusercontent.com/10383417/171649245-10d8ccc5-b9af-4c1f-8f40-54067b896f63.png)

### Example

```python
import audb
import audeer
import audinterface


db = audb.load(
    'emodb',
    version='1.2.0',
    format='wav',
    mixdown=True,
    sampling_rate=16000,
)

def process_func(x, sr):
    return [x.mean(), x.min(), x.max()]

feature = audinterface.Feature(
    ['mean', 'min', 'max'],
    process_func=process_func,
)
feature.process_index(
    db.files,
    cache_root='cache',
)
```
```
                                                                                         mean  ...       max
file                                               start  end                                  ...          
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:01.898250    -0.000311  ...  0.999969
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:01.611250    -0.000312  ...  0.935303
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:01.877812500 -0.000296  ...  0.975800
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:02.006250    -0.000171  ...  0.999634
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:01.439812500 -0.000331  ...  0.889465
...                                                                                       ...  ...       ...
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:03.442687500 -0.000268  ...  0.788452
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:03.500625    -0.001218  ...  0.999969
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:03.934187500 -0.001157  ...  0.999969
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:02.414125    -0.000195  ...  0.999969
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:02.522499999 -0.000464  ...  0.999908

[535 rows x 3 columns]
```

```python
cache_path = audeer.path('cache', f'{audformat.utils.hash(db.files)}.pkl')
pd.read_pickle(cache_path)
```
```
                                                                                         mean  ...       max
file                                               start  end                                  ...          
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:01.898250    -0.000311  ...  0.999969
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:01.611250    -0.000312  ...  0.935303
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:01.877812500 -0.000296  ...  0.975800
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:02.006250    -0.000171  ...  0.999634
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:01.439812500 -0.000331  ...  0.889465
...                                                                                       ...  ...       ...
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:03.442687500 -0.000268  ...  0.788452
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:03.500625    -0.001218  ...  0.999969
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:03.934187500 -0.001157  ...  0.999969
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:02.414125    -0.000195  ...  0.999969
/media/jwagner/Data/audb/emodb/1.2.0/fe182b91/w... 0 days 0 days 00:00:02.522499999 -0.000464  ...  0.999908

[535 rows x 3 columns]
```
