### PR TITLE
DOC: add usage section

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,19 +23,23 @@ source_suffix = '.rst'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 pygments_style = None
 extensions = [
+    'jupyter_sphinx',
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',  # support for Google-style docstrings
     'sphinx_autodoc_typehints',
     'sphinx.ext.viewcode',
     'sphinx.ext.intersphinx',
     'sphinx.ext.autosectionlabel',
+    'sphinx_copybutton',  # for "copy to clipboard" buttons
 ]
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'audformat': ('https://audeering.github.io/audformat/', None),
+    'audobject': ('https://audeering.github.io/audobject/', None),
     'audresample': ('https://audeering.github.io/audresample/', None),
+    'opensmile': ('https://audeering.github.io/opensmile-python/', None),
 }
 # Disable Gitlab as we need to sign in
 linkcheck_ignore = [

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,6 +8,7 @@
     :hidden:
 
     installation
+    usage
 
 .. Warning: the usage of genindex is a hack to get a TOC entry, see
 .. https://stackoverflow.com/a/42310803. This might break the usage of sphinx if

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,6 @@
 audb
 audeer
+auditok
 jupyter-sphinx
 librosa
 sphinx

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,7 @@
+audb
 audeer
+jupyter-sphinx
 sphinx
 sphinx-audeering-theme
 sphinx-autodoc-typehints
+sphinx-copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 audb
 audeer
 jupyter-sphinx
+librosa
 sphinx
 sphinx-audeering-theme
 sphinx-autodoc-typehints

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -247,7 +247,7 @@ Segmentation interface
         return index
 
     interface = audinterface.Segment(process_func=segments)
-    idx = interafce.process_file(files[0])
+    idx = interface.process_file(files[0])
     idx
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -215,6 +215,12 @@ and re-instantiate it from there.
 Segmentation interface
 ----------------------
 
+When the result of the processing function is an index
+it is recommended to use :class:`audinterface.Segment`,
+which returns a segmented index conform to audformat_.
+An example for such a processing function
+would be a voice activity detection algorithm.
+
 .. jupyter-execute::
 
     import auditok

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -112,6 +112,49 @@ and assigns names to single features.
     df
 
 
+Create a framewise feature extractor
+------------------------------------
+
+If the feature extractor does not return
+one set of features for the whole signal,
+but does return features
+in a framewise manner,
+you should specify the ``win_dur``
+and ``hop_dur`` arguments
+of :class:`audinterface.Feature`.
+
+.. jupyter-execute::
+
+    def features(signal, sampling_rate, win_dur, hop_dur):
+        win_dur = int(win_dur * sampling_rate)
+        hop_dur = int(hop_dur * sampling_rate)
+        dur = signal.shape[1]
+        starts = np.arange(0, dur - win_dur, hop_dur)
+        ends = np.arange(win_dur, dur, hop_dur)
+        mean = np.array(
+            [
+                [signal[:, s:e].mean()]
+                for s, e in zip(starts, ends)
+            ]
+        )
+        return mean.T  # return with shape (num_features, num_frames)
+
+    win_dur = 0.2
+    hop_dur = 0.1
+    interface = audinterface.Feature(
+        ['mean'],
+        process_func=features,
+        process_func_args={
+            'win_dur': win_dur,
+            'hop_dur': hop_dur,
+        },
+        win_dur=win_dur,
+        hop_dur=hop_dur,
+    )
+    df = interface.process_index(index)
+    df
+
+
 Create a serializable feature extractor
 ---------------------------------------
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -33,7 +33,7 @@ to audio files.
 The only prerequisite is
 the algorithm provides a callable
 that takes at least the signal
-as a :class:`np.ndarray`
+as a :class:`numpy.ndarray`
 and the sampling rate as input.
 
 The interface can then apply the algorithm

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -28,7 +28,7 @@ Usage
 The basic idea of :mod:`audinterface` is
 to provide easy and standardized interfaces
 to apply a machine learning model,
-or other digital signal processing algorithms (DSP)
+or other digital signal processing algorithms
 to audio files.
 The only prerequisite is
 the algorithm provides a callable
@@ -59,8 +59,8 @@ and an index.
     index = db['emotion'].index
 
 
-DSP algorithm returning a series
---------------------------------
+Create a processing interface
+-----------------------------
 
 Let's assume we want to calculate the root mean square (RMS)
 value in dB.
@@ -80,7 +80,7 @@ and create an interface for it using :class:`audinterface.Process`.
 The following three commands
 apply the algorithm
 and all return the same result
-as a :class:`pd.Series`.
+as a :class:`pandas.Series`.
 
 .. jupyter-execute::
 
@@ -90,13 +90,13 @@ as a :class:`pd.Series`.
     y
 
 
-DSP algorithm returning a dataframe
------------------------------------
+Create a feature extractor
+--------------------------
 
-When using a DSP algorithm as feature extractor,
+When using an algorithm as feature extractor,
 it is recommended to use :class:`audinterface.Feature`,
-which returns results as a :class:`pd.DataFrame`
-and assigns names to the single features.
+which returns results as a :class:`pandas.DataFrame`
+and assigns names to single features.
 
 .. jupyter-execute::
 
@@ -112,8 +112,8 @@ and assigns names to the single features.
     df
 
 
-Creating a feature extraction object
-------------------------------------
+Create a serializable feature extractor
+---------------------------------------
 
 To use a feature extractor as an input transform
 of a machine learning model

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,0 +1,156 @@
+.. Specify pandas format output in cells
+.. jupyter-execute::
+    :hide-code:
+    :hide-output:
+
+    import pandas as pd
+
+
+    def series_to_html(self):
+        df = self.to_frame()
+        df.columns = ['']
+        return df._repr_html_()
+
+
+    setattr(pd.Series, '_repr_html_', series_to_html)
+    pd.set_option('display.max_rows', 6)
+
+
+Usage
+=====
+
+The basic idea of :mod:`audinterface` is
+to provide easy and standardized interfaces
+to apply a machine learning model,
+or other digital signal processing algorithms (DSP)
+to audio files.
+The only prerequisite is
+the algorithm provides a callable
+that takes at least the signal
+as a :class:`np.ndarray`
+and the sampling rate as input.
+
+The interface can then apply the algorithm
+on a list of files,
+a folder,
+or an index conform to the audformat_ database specification.
+Results are always returned containing a `segmented index`_.
+In the following we load three files from the emodb_ database
+and define a list of files,
+a folder,
+and an index.
+
+.. jupyter-execute::
+
+    import audb
+    import os
+
+    media = ['wav/03a01Fa.wav', 'wav/03a01Nc.wav', 'wav/03a01Wa.wav']
+    db = audb.load('emodb', version='1.2.0', media=media, verbose=False)
+
+    files = list(db.files)
+    folder = os.path.dirname(files[0])
+    index = db['emotion'].index
+
+
+DSP algorithm returning a series
+--------------------------------
+
+Let's assume we want to calculate the root mean square (RMS)
+value in dB.
+We first define the function
+and create an interface for it using :class:`audinterface.Process`.
+
+.. jupyter-execute::
+
+    import audinterface
+    import numpy as np
+
+    def rms(signal, sampling_rate):
+        return 20 * np.log10(np.sqrt(np.mean(signal ** 2)))
+
+    interface = audinterface.Process(process_func=rms)
+
+The following three commands
+apply the algorithm
+and all return the same result
+as a :class:`pd.Series`.
+
+.. jupyter-execute::
+
+    y = interface.process_files(files)
+    y = interface.process_folder(folder)
+    y = interface.process_index(index)
+    y
+
+
+DSP algorithm returning a dataframe
+-----------------------------------
+
+When using a DSP algorithm as feature extractor,
+it is recommended to use :class:`audinterface.Feature`,
+which returns results as a :class:`pd.DataFrame`
+and assigns names to the single features.
+
+.. jupyter-execute::
+
+    def features(signal, sampling_rate):
+        return [signal.mean(), signal.std()]
+
+    interface = audinterface.Feature(
+        ['mean', 'std'],
+        process_func=features,
+    )
+
+    df = interface.process_index(index)
+    df
+
+
+Creating a feature extraction object
+------------------------------------
+
+To use a feature extractor as an input transform
+of a machine learning model
+it is recommend to provide it in a serializable way
+so it can be `stored as part of the model`_.
+One example of such a feature extractor is :class:`opensmile.Smile`.
+
+To create such a feature extractor,
+we create a class that inherits
+from :class:`audinterface.Feature`
+and :class:`audobject.Object`.
+
+.. jupyter-execute::
+
+    import audobject
+
+    class MeanStd(audinterface.Feature, audobject.Object):
+
+        def __init__(self):
+            super().__init__(
+                ['mean', 'std'],
+                process_func=self.features,
+            )
+
+        def features(self, signal, sampling_rate):
+            return [signal.mean(), signal.std()]
+            
+    fex = MeanStd()
+    df = fex.process_index(index)
+    df
+
+The advantage of the feature extraction object is
+that we can save it to a YAML file
+and re-instantiate it from there.
+
+.. jupyter-execute::
+
+    fex.to_yaml('mean-std.yml')
+    fex2 = audobject.from_yaml('mean-std.yml')
+    df = fex2.process_index(index)
+    df
+
+.. _audformat: https://audeering.github.io/audformat/
+.. _emodb: http://emodb.bilderbar.info
+.. _segmented index: https://audeering.github.io/audformat/data-tables.html#segmented
+.. _stored as part of the model: https://audeering.github.io/audonnx/usage.html#export-model

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -151,8 +151,8 @@ and re-instantiate it from there.
 
 .. jupyter-execute::
 
-    fex.to_yaml('mean-std.yml')
-    fex2 = audobject.from_yaml('mean-std.yml')
+    fex.to_yaml('mean-std.yaml')
+    fex2 = audobject.from_yaml('mean-std.yaml')
     df = fex2.process_index(index)
     df
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -94,10 +94,10 @@ as a :class:`pandas.Series`.
 Feature extractor
 -----------------
 
-When using an algorithm as feature extractor,
+When the result of the processing function has multiple dimensions
 it is recommended to use :class:`audinterface.Feature`,
-which returns results as a :class:`pandas.DataFrame`
-and assigns names to single features.
+which returns a :class:`pandas.DataFrame`
+and assigns names to the dimensions/features.
 
 .. jupyter-execute::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -122,6 +122,10 @@ in a framewise manner,
 you should specify the ``win_dur``
 and ``hop_dur`` arguments
 of :class:`audinterface.Feature`.
+It's also important the feature extraction function
+returns the value in the correct shape,
+namely ``(num_channels, num_features, num_frames)``,
+whereas the first dimension is optionally.
 
 .. jupyter-execute::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,6 +14,7 @@
 
     setattr(pd.Series, '_repr_html_', series_to_html)
     pd.set_option('display.max_rows', 6)
+    pd.set_option('display.max_columns', 3)
 
 .. Specify version for storing and loading objects to YAML
 .. jupyter-execute::
@@ -129,31 +130,33 @@ whereas the first dimension is optionally.
 
 .. jupyter-execute::
 
-    def features(signal, sampling_rate, win_dur, hop_dur):
-        win_dur = int(win_dur * sampling_rate)
-        hop_dur = int(hop_dur * sampling_rate)
-        dur = signal.shape[1]
-        starts = np.arange(0, dur - win_dur, hop_dur)
-        ends = np.arange(win_dur, dur, hop_dur)
-        mean = np.array(
-            [
-                [signal[:, s:e].mean()]
-                for s, e in zip(starts, ends)
-            ]
-        )
-        return mean.T  # return with shape (num_features, num_frames)
+    import librosa
 
-    win_dur = 0.2
-    hop_dur = 0.1
+    def features(signal, sampling_rate, win_dur, hop_dur, n_mfcc):
+        hop_length = int(hop_dur * sampling_rate)
+        win_length = int(win_dur * sampling_rate)
+        mfcc = librosa.feature.mfcc(
+            y=signal,
+            sr=sampling_rate,
+            n_mfcc=13,
+            hop_length=hop_length,
+            win_length=win_length,
+        )
+        return mfcc
+
+    win_dur = 0.02
+    hop_dur = 0.01
+    n_mfcc = 13
     interface = audinterface.Feature(
-        ['mean'],
+        [f'mfcc-{idx}' for idx in range(n_mfcc)],
         process_func=features,
         process_func_args={
             'win_dur': win_dur,
             'hop_dur': hop_dur,
+            'n_mfcc': n_mfcc,
         },
-        win_dur=win_dur,
         hop_dur=hop_dur,
+        win_dur=win_dur,
     )
     df = interface.process_index(index)
     df

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -15,6 +15,12 @@
     setattr(pd.Series, '_repr_html_', series_to_html)
     pd.set_option('display.max_rows', 6)
 
+.. Specify version for storing and loading objects to YAML
+.. jupyter-execute::
+    :hide-code:
+
+    __version__ = '1.0.0'
+
 
 Usage
 =====
@@ -134,7 +140,7 @@ and :class:`audobject.Object`.
 
         def features(self, signal, sampling_rate):
             return [signal.mean(), signal.std()]
-            
+
     fex = MeanStd()
     df = fex.process_index(index)
     df

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -96,7 +96,7 @@ as a :class:`pandas.Series`.
     y
 
 
-Feature interafce
+Feature interface
 -----------------
 
 When the result of the processing function has multiple dimensions
@@ -118,7 +118,7 @@ and assigns names to the dimensions/features.
     df
 
 
-Framewise feature interafce
+Framewise feature interface
 ---------------------------
 
 If a processing function does not return
@@ -167,7 +167,7 @@ whereas the first dimension is optionally.
     df
 
 
-Serializable feature interafce
+Serializable feature interface
 ------------------------------
 
 To use a feature extractor as an input transform

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -246,7 +246,7 @@ Segmentation interface
         )
         return index
 
-    interafce = audinterface.Segment(process_func=segments)
+    interface = audinterface.Segment(process_func=segments)
     idx = interafce.process_file(files[0])
     idx
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -59,8 +59,8 @@ and an index.
     index = db['emotion'].index
 
 
-Create a processing interface
------------------------------
+Processing interface
+--------------------
 
 Let's assume we want to calculate the root mean square (RMS)
 value in dB.
@@ -90,8 +90,8 @@ as a :class:`pandas.Series`.
     y
 
 
-Create a feature extractor
---------------------------
+Feature extractor
+-----------------
 
 When using an algorithm as feature extractor,
 it is recommended to use :class:`audinterface.Feature`,
@@ -112,8 +112,8 @@ and assigns names to single features.
     df
 
 
-Create a framewise feature extractor
-------------------------------------
+Framewise feature extractor
+---------------------------
 
 If the feature extractor does not return
 one set of features for the whole signal,
@@ -159,8 +159,8 @@ whereas the first dimension is optionally.
     df
 
 
-Create a serializable feature extractor
----------------------------------------
+Serializable feature extractor
+------------------------------
 
 To use a feature extractor as an input transform
 of a machine learning model

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -13,7 +13,7 @@
 
 
     def index_to_html(self):
-        return self.to_frame(index=False)._repr_html_()
+        return self.to_frame(index=False).to_html(index=False)
 
 
     setattr(pd.Series, '_repr_html_', series_to_html)


### PR DESCRIPTION
Closes #5.

This adds a first basic usage section to the documentation, covering:

* using `audinterface.Process`
* using `audinterface.Feature`
* building a feature extraction object with `audinterface.Feature` and `audobject.Object`

Building the documentation will fail as I get the following warning due to storing and loading the feature extraction object:

```
WARNING: Cell printed to stderr:
/home/audeering.local/hwierstorf/.envs/audinterface/lib/python3.8/site-packages/audobject/core/utils.py:51: RuntimeWarning: Could not determine a version for module '__main__'.
  warnings.warn(
```

Any idea how to avoid this?