### PR TITLE
DOC: add docstring examples

### DIFF
--- a/audinterface/__init__.py
+++ b/audinterface/__init__.py
@@ -22,18 +22,6 @@ You can inherit from the classes
 or just instantiate them
 to get some standard implementations of those methods.
 
-Example:
-    >>> import numpy as np
-    >>> def process_func(signal, sampling_rate):
-    ...     return signal.shape[1] / sampling_rate
-    ...
-    >>> model = Process(process_func=process_func)
-    >>> signal = np.array([1., 2., 3.])
-    >>> model.process_signal(signal, sampling_rate=3)
-    start   end
-    0 days  0 days 00:00:01    1.0
-    dtype: float64
-
 """
 from audinterface import utils
 from audinterface.core.feature import (

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -90,7 +90,30 @@ class Feature:
             and ``win_dur is not None``
         ValueError: if ``hop_dur`` is specified, but not ``win_dur``
 
-    """
+    Example:
+        >>> def mean_std(signal, sampling_rate):
+        ...     return [signal.mean(), signal.std()]
+        >>> interface = Feature(['mean', 'std'], process_func=mean_std)
+        >>> signal = np.array([1., 2., 3.])
+        >>> interface(signal, sampling_rate=3)
+        array([[[2.        ],
+                [0.81649658]]])
+        >>> interface.process_signal(signal, sampling_rate=3)
+                                mean       std
+        start  end
+        0 days 0 days 00:00:01   2.0  0.816497
+        >>> import audb
+        >>> import audformat
+        >>> db = audb.load('emodb', version='1.2.0', media='wav/03a01Fa.wav', verbose=False)
+        >>> index = db['emotion'].index
+        >>> df = interface.process_index(index)
+        >>> df.index = audformat.utils.map_file_path(df.index, os.path.basename)
+        >>> df
+                                                       mean       std
+        file        start  end
+        03a01Fa.wav 0 days 0 days 00:00:01.898250 -0.000311  0.082317
+
+    """  # noqa: E501
     def __init__(
             self,
             feature_names: typing.Union[str, typing.Sequence[str]],

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -103,17 +103,20 @@ class Feature:
         start  end
         0 days 0 days 00:00:01   2.0  0.816497
         >>> import audb
-        >>> import audformat
-        >>> db = audb.load('emodb', version='1.2.0', media='wav/03a01Fa.wav', verbose=False)
+        >>> db = audb.load(
+        ...     'emodb',
+        ...     version='1.2.0',
+        ...     media='wav/03a01Fa.wav',
+        ...     full_path=False,
+        ...     verbose=False,
+        ... )
         >>> index = db['emotion'].index
-        >>> df = interface.process_index(index)
-        >>> df.index = audformat.utils.map_file_path(df.index, os.path.basename)
-        >>> df
-                                                       mean       std
-        file        start  end
-        03a01Fa.wav 0 days 0 days 00:00:01.898250 -0.000311  0.082317
+        >>> interface.process_index(index, root=db.root)
+                                                           mean       std
+        file            start  end
+        wav/03a01Fa.wav 0 days 0 days 00:00:01.898250 -0.000311  0.082317
 
-    """  # noqa: E501
+    """
     def __init__(
             self,
             feature_names: typing.Union[str, typing.Sequence[str]],

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -652,20 +652,20 @@ class ProcessWithContext:
         ValueError: if ``resample = True``, but ``sampling_rate = None``
 
     Example:
-        >>> def mean(signal, sampling_rate, starts, ends):
-        ...     aggregated_mean = 0
-        ...     for start, end in zip(starts, ends):
-        ...         start *= sampling_rate
-        ...         end *= sampling_rate
-        ...         aggregated_mean += signal[:, start:end].mean()
-        ...     return aggregated_mean
-        >>> interface = ProcessWithContext(process_func=mean)
+        >>> def running_mean(signal, sampling_rate, starts, ends):
+        ...     means_per_segment = [
+        ...         signal[:, start:end].mean()
+        ...         for start, end in zip(starts, ends)
+        ...     ]
+        ...     cumsum = np.cumsum(np.pad(means_per_segment, 1))
+        ...     return (cumsum[2:] - cumsum[:-2]) / float(2)
+        >>> interface = ProcessWithContext(process_func=running_mean)
         >>> signal = np.array([1., 2., 3., 1., 2., 3.])
         >>> sampling_rate = 3
-        >>> starts = [0, 1]
-        >>> ends = [1, 2]
+        >>> starts = [0, sampling_rate]
+        >>> ends = [sampling_rate, 2 * sampling_rate]
         >>> interface(signal, sampling_rate, starts, ends)
-        4.0
+        array([2., 1.])
         >>> import audb
         >>> db = audb.load(
         ...     'emodb',
@@ -678,9 +678,14 @@ class ProcessWithContext:
         >>> starts = [0, 0.1, 0.2]
         >>> ends = [0.5, 0.6, 0.7]
         >>> index = audformat.segmented_index(files, starts, ends)
-        >>> # y = interface.process_index(index, root=db.root)
+        >>> interface.process_index(index, root=db.root)
+        file             start                   end
+        wav/03a01Fa.wav  0 days 00:00:00         0 days 00:00:00.500000   -0.000261
+                         0 days 00:00:00.100000  0 days 00:00:00.600000   -0.000199
+                         0 days 00:00:00.200000  0 days 00:00:00.700000   -0.000111
+        dtype: float32
 
-    """
+    """  # noqa: E501
     def __init__(
             self,
             *,
@@ -770,8 +775,6 @@ class ProcessWithContext:
                 mask = index.isin([file], 0)
                 select = index[mask].droplevel(0)
                 signal, sampling_rate = utils.read_audio(file, root=root)
-                print(idx)
-                print(file)
                 ys[idx] = pd.Series(
                     self.process_signal_from_index(
                         signal, sampling_rate, select,

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -64,17 +64,20 @@ class Process:
         0 days  0 days 00:00:01   2.0
         dtype: float64
         >>> import audb
-        >>> import audformat
-        >>> db = audb.load('emodb', version='1.2.0', media='wav/03a01Fa.wav', verbose=False)
+        >>> db = audb.load(
+        ...     'emodb',
+        ...     version='1.2.0',
+        ...     media='wav/03a01Fa.wav',
+        ...     full_path=False,
+        ...     verbose=False,
+        ... )
         >>> index = db['emotion'].index
-        >>> y = interface.process_index(index)
-        >>> y.index = audformat.utils.map_file_path(y.index, os.path.basename)
-        >>> y
-        file         start   end
-        03a01Fa.wav  0 days  0 days 00:00:01.898250    -0.000311
+        >>> interface.process_index(index, root=db.root)
+        file             start   end
+        wav/03a01Fa.wav  0 days  0 days 00:00:01.898250    -0.000311
         dtype: float32
 
-    """  # noqa: E501
+    """
     def __init__(
             self,
             *,
@@ -664,17 +667,20 @@ class ProcessWithContext:
         >>> interface(signal, sampling_rate, starts, ends)
         4.0
         >>> import audb
-        >>> import audformat
-        >>> db = audb.load('emodb', version='1.2.0', media='wav/03a01Fa.wav', verbose=False)
+        >>> db = audb.load(
+        ...     'emodb',
+        ...     version='1.2.0',
+        ...     media='wav/03a01Fa.wav',
+        ...     full_path=False,
+        ...     verbose=False,
+        ... )
         >>> files = list(db.files) * 3
         >>> starts = [0, 0.1, 0.2]
         >>> ends = [0.5, 0.6, 0.7]
         >>> index = audformat.segmented_index(files, starts, ends)
-        >>> # y = interface.process_index(index)
-        >>> # y.index = audformat.utils.map_file_path(y.index, os.path.basename)
-        >>> # y
+        >>> # y = interface.process_index(index, root=db.root)
 
-    """  # noqa: E501
+    """
     def __init__(
             self,
             *,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -156,24 +156,27 @@ class Segment:
                     ('0 days 00:00:00.700000', '0 days 00:00:00.900000')],
                    names=['start', 'end'])
         >>> import audb
-        >>> import audformat
-        >>> db = audb.load('emodb', version='1.2.0', media='wav/03a01Fa.wav', verbose=False)
+        >>> db = audb.load(
+        ...     'emodb',
+        ...     version='1.2.0',
+        ...     media='wav/03a01Fa.wav',
+        ...     full_path=False,
+        ...     verbose=False,
+        ... )
         >>> interface = Segment(
         ...     process_func=segment,
         ...     process_func_args={'win_size': 0.5, 'hop_size': 0.25},
         ... )
-        >>> index = interface.process_index(db['emotion'].index)
-        >>> index = audformat.utils.map_file_path(index, os.path.basename)
-        >>> index
-        MultiIndex([('03a01Fa.wav',        '0 days 00:00:00', ...),
-                    ('03a01Fa.wav', '0 days 00:00:00.250000', ...),
-                    ('03a01Fa.wav', '0 days 00:00:00.500000', ...),
-                    ('03a01Fa.wav', '0 days 00:00:00.750000', ...),
-                    ('03a01Fa.wav',        '0 days 00:00:01', ...),
-                    ('03a01Fa.wav', '0 days 00:00:01.250000', ...)],
+        >>> interface.process_index(db['emotion'].index, root=db.root)
+        MultiIndex([('wav/03a01Fa.wav',        '0 days 00:00:00', ...),
+                    ('wav/03a01Fa.wav', '0 days 00:00:00.250000', ...),
+                    ('wav/03a01Fa.wav', '0 days 00:00:00.500000', ...),
+                    ('wav/03a01Fa.wav', '0 days 00:00:00.750000', ...),
+                    ('wav/03a01Fa.wav',        '0 days 00:00:01', ...),
+                    ('wav/03a01Fa.wav', '0 days 00:00:01.250000', ...)],
                    names=['file', 'start', 'end'])
 
-    """  # noqa: E501
+    """
     def __init__(
             self,
             *,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -134,15 +134,9 @@ class Segment:
     Example:
         >>> def segment(signal, sampling_rate, *, win_size=0.2, hop_size=0.1):
         ...     size = signal.shape[1] / sampling_rate
-        ...     starts = np.arange(0, size - win_size, hop_size)
-        ...     ends = np.arange(win_size, size, hop_size)
-        ...     return pd.MultiIndex.from_tuples(
-        ...         [
-        ...             (pd.Timedelta(s, unit='s'), pd.Timedelta(e, unit='s'))
-        ...             for s, e in zip(starts, ends)
-        ...         ],
-        ...         names=['start', 'end'],
-        ...     )
+        ...     starts = pd.to_timedelta(np.arange(0, size - win_size, hop_size), unit='s')
+        ...     ends = pd.to_timedelta(np.arange(win_size, size, hop_size), unit='s')
+        ...     return pd.MultiIndex.from_tuples(zip(starts, ends), names=['start', 'end'])
         >>> interface = Segment(process_func=segment)
         >>> signal = np.array([1., 2., 3.])
         >>> interface(signal, sampling_rate=3)
@@ -176,7 +170,7 @@ class Segment:
                     ('wav/03a01Fa.wav', '0 days 00:00:01.250000', ...)],
                    names=['file', 'start', 'end'])
 
-    """
+    """  # noqa: E501
     def __init__(
             self,
             *,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -131,7 +131,49 @@ class Segment:
     Raises:
         ValueError: if ``resample = True``, but ``sampling_rate = None``
 
-    """
+    Example:
+        >>> def segment(signal, sampling_rate, *, win_size=0.2, hop_size=0.1):
+        ...     size = signal.shape[1] / sampling_rate
+        ...     starts = np.arange(0, size - win_size, hop_size)
+        ...     ends = np.arange(win_size, size, hop_size)
+        ...     return pd.MultiIndex.from_tuples(
+        ...         [
+        ...             (pd.Timedelta(s, unit='s'), pd.Timedelta(e, unit='s'))
+        ...             for s, e in zip(starts, ends)
+        ...         ],
+        ...         names=['start', 'end'],
+        ...     )
+        >>> interface = Segment(process_func=segment)
+        >>> signal = np.array([1., 2., 3.])
+        >>> interface(signal, sampling_rate=3)
+        MultiIndex([(       '0 days 00:00:00', '0 days 00:00:00.200000'),
+                    ('0 days 00:00:00.100000', '0 days 00:00:00.300000'),
+                    ('0 days 00:00:00.200000', '0 days 00:00:00.400000'),
+                    ('0 days 00:00:00.300000', '0 days 00:00:00.500000'),
+                    ('0 days 00:00:00.400000', '0 days 00:00:00.600000'),
+                    ('0 days 00:00:00.500000', '0 days 00:00:00.700000'),
+                    ('0 days 00:00:00.600000', '0 days 00:00:00.800000'),
+                    ('0 days 00:00:00.700000', '0 days 00:00:00.900000')],
+                   names=['start', 'end'])
+        >>> import audb
+        >>> import audformat
+        >>> db = audb.load('emodb', version='1.2.0', media='wav/03a01Fa.wav', verbose=False)
+        >>> interface = Segment(
+        ...     process_func=segment,
+        ...     process_func_args={'win_size': 0.5, 'hop_size': 0.25},
+        ... )
+        >>> index = interface.process_index(db['emotion'].index)
+        >>> index = audformat.utils.map_file_path(index, os.path.basename)
+        >>> index
+        MultiIndex([('03a01Fa.wav',        '0 days 00:00:00', ...),
+                    ('03a01Fa.wav', '0 days 00:00:00.250000', ...),
+                    ('03a01Fa.wav', '0 days 00:00:00.500000', ...),
+                    ('03a01Fa.wav', '0 days 00:00:00.750000', ...),
+                    ('03a01Fa.wav',        '0 days 00:00:01', ...),
+                    ('03a01Fa.wav', '0 days 00:00:01.250000', ...)],
+                   names=['file', 'start', 'end'])
+
+    """  # noqa: E501
     def __init__(
             self,
             *,

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -125,7 +125,12 @@ def read_audio(
 
     Example:
         >>> import audb
-        >>> media = audb.load_media('emodb', 'wav/03a01Fa.wav', version='1.2.0', verbose=False)
+        >>> media = audb.load_media(
+        ...     'emodb',
+        ...     'wav/03a01Fa.wav',
+        ...     version='1.2.0',
+        ...     verbose=False,
+        ... )
         >>> signal, sampling_rate = read_audio(media[0], end=pd.Timedelta(0.01, unit='s'))
         >>> signal.shape
         (1, 160)

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -123,7 +123,14 @@ def read_audio(
         signal: array with signal values in shape ``(channels, samples)``
         sampling_rate: sampling rate in Hz
 
-    """
+    Example:
+        >>> import audb
+        >>> media = audb.load_media('emodb', 'wav/03a01Fa.wav', version='1.2.0', verbose=False)
+        >>> signal, sampling_rate = read_audio(media[0], end=pd.Timedelta(0.01, unit='s'))
+        >>> signal.shape
+        (1, 160)
+
+    """  # noqa: E501
     if root is not None and not os.path.isabs(file):
         file = os.path.join(root, file)
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,6 +53,11 @@ autodoc_mock_imports = [
 autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 2
 
+# Do not copy prompot output
+copybutton_prompt_text = r'>>> |\.\.\. |$ '
+copybutton_prompt_is_regexp = True
+
+
 # HTML --------------------------------------------------------------------
 html_theme = 'sphinx_audeering_theme'
 html_theme_options = {

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+audb
 pytest
 pytest-flake8
 pytest-doctestplus


### PR DESCRIPTION
Closes #11 

This adds examples to all API functions and classes.
In addition, it removes the example from `__init__.py` as we now have the same in the docstrings.

### audinterface.Feature

![image](https://user-images.githubusercontent.com/173624/173035856-519b4563-9dfd-4840-bb74-7fedae365bcb.png)

### audinterafce.Process

![image](https://user-images.githubusercontent.com/173624/173035919-23815d9a-3333-4576-9bbb-7ee32046cfa8.png)

### audinterface.ProcessWithContext

![image](https://user-images.githubusercontent.com/173624/173045654-80723b1a-2a63-43e4-935a-5f295b49898f.png)

### audinterface.Segment

![image](https://user-images.githubusercontent.com/173624/173056605-f15d563b-db33-47ed-af47-b8acc8a07d69.png)

### audinterface.utils.read_audio

![image](https://user-images.githubusercontent.com/173624/172827740-7e7636d9-4652-4a58-abad-e581bb1bfd73.png)

