### PR TITLE
Allow single valued context processing function

### DIFF
--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -1,3 +1,4 @@
+import collections
 import errno
 import os
 import typing
@@ -819,7 +820,7 @@ class ProcessWithContext:
         y = self(signal, sampling_rate, starts_i, ends_i)
 
         # For an empty Series we force the dtype
-        if len(y) == 0:
+        if isinstance(y, collections.abc.Iterable) and len(y) == 0:
             y = pd.Series(y, index=index, dtype=object)
         else:
             y = pd.Series(y, index=index)

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -41,6 +41,29 @@ def test_process_func_args():
         )
 
 
+def test_process_func_single_value(tmpdir):
+    # Test context functions that return only a single value
+    # https://github.com/audeering/audinterface/issues/47
+
+    def process_func(signal, sampling_rate, starts, ends):
+        return 1
+
+    process = audinterface.ProcessWithContext(process_func=process_func)
+
+    # create file
+    sampling_rate = 8000
+    signal = np.random.uniform(-1.0, 1.0, (1, 3 * sampling_rate))
+    root = str(tmpdir.mkdir('wav'))
+    file = 'file.wav'
+    path = os.path.join(root, file)
+    af.write(path, signal, sampling_rate)
+    index = audformat.segmented_index([path] * 2, [0, 1], [1, 2])
+
+    y = process.process_index(index)
+    y_expected = pd.Series([1, 1], index=index)
+    pd.testing.assert_series_equal(y, y_expected)
+
+
 def test_process_index(tmpdir):
 
     process = audinterface.ProcessWithContext(


### PR DESCRIPTION
Closes #47 

This allows processing functions with a single valued return value.

Currently, this is not in line with the docs which state

![image](https://user-images.githubusercontent.com/173624/173054627-a134f19b-1fb1-41c3-85d7-6a9342871713.png)

But we seem to allow also that the processing function returns an empty sequence.

An alternative implementation would always check if the number of returned values match the number of segments, but this would break the current behavior for empty sequences.