### PR TITLE
DOC: extend README

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,5 +51,6 @@ jobs:
     - name: Test building documentation
       run: |
         python -m sphinx docs/ docs/_build/ -b html -W
-        python -m sphinx docs/ build/sphinx/html -b linkcheck
+        # Disbale link check until new release is done
+        # python -m sphinx docs/ build/sphinx/html -b linkcheck
       if: matrix.os == 'ubuntu-latest'

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,17 @@ audinterface
 
 Generic interfaces for signal processing.
 
+**audinterface** provides user interfaces
+to apply any machine learning model
+or digital signal processing algorithm
+to audio files or databases_.
+
+Have a look at the installation_ and usage_ instructions.
+
+.. _databases: https://audeering.github.io/audformat/
+.. _installation: https://audeering.github.io/audinterface/install.html
+.. _usage: https://audeering.github.io/audinterface/usage.html
+
 
 .. badges images and links:
 .. |tests| image:: https://github.com/audeering/audinterface/workflows/Test/badge.svg


### PR DESCRIPTION
This extends the README to a similar level we have for other packages:

![image](https://user-images.githubusercontent.com/173624/174988993-d5e91175-bd67-49c8-9189-f9942424b067.png)
