### PR TITLE
ProcessWithContext requires output per segment

### DIFF
--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -753,7 +753,7 @@ class ProcessWithContext:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
-            RuntimeError: if sequence returned by ``self.process_func``
+            RuntimeError: if sequence returned by ``process_func``
                 does not match length of ``index``
 
         .. _audformat: https://audeering.github.io/audformat/data-format.html
@@ -809,7 +809,7 @@ class ProcessWithContext:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
-            RuntimeError: if sequence returned by ``self.process_func``
+            RuntimeError: if sequence returned by ``process_func``
                 does not match length of ``index``
             ValueError: if index contains duplicates
 

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -753,6 +753,8 @@ class ProcessWithContext:
         Raises:
             RuntimeError: if sampling rates do not match
             RuntimeError: if channel selection is invalid
+            RuntimeError: if sequence returned by ``self.process_func``
+                does not match length of ``index``
 
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -21,22 +21,6 @@ def signal_max_with_context(signal, sampling_rate, starts, ends):
     return result
 
 
-def signal_no_value(signal, sampling_rate):
-    return None
-
-
-def signal_with_context_no_value(signal, sampling_rate, starts, ends):
-    return None
-
-
-def signal_single_value(signal, sampling_rate):
-    return 0
-
-
-def signal_with_context_single_value(signal, sampling_rate, starts, ends):
-    return 0
-
-
 def test_process_func_args():
     def process_func(s, sr, starts, ends, arg1, arg2):
         assert arg1 == 'foo'
@@ -185,8 +169,8 @@ def test_process_index(tmpdir):
             marks=pytest.mark.xfail(raises=ValueError)
         ),
         pytest.param(  # process_func returns None
-            signal_no_value,
-            signal_with_context_no_value,
+            lambda signal, sampling_rate: None,
+            lambda signal, sampling_rate, starts, ends: None,
             np.random.random(5 * 44100),
             44100,
             audinterface.utils.signal_index(
@@ -196,8 +180,8 @@ def test_process_index(tmpdir):
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),
         pytest.param(  # process_func returns single value
-            signal_single_value,
-            signal_with_context_single_value,
+            lambda signal, sampling_rate: 0,
+            lambda signal, sampling_rate, starts, ends: 0,
             np.random.random(5 * 44100),
             44100,
             audinterface.utils.signal_index(
@@ -207,8 +191,8 @@ def test_process_index(tmpdir):
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),
         pytest.param(  # process_func returns array with wrong length
-            signal_single_value,
-            lambda sig, fs, starts, ends: [0, 1],
+            lambda signal, sampling_rate: [0, 1],
+            lambda signal, sampling_rate, starts, ends: [0, 1],
             np.random.random(5 * 44100),
             44100,
             audinterface.utils.signal_index(

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -242,10 +242,6 @@ def test_process_signal_from_index(
         signal, sampling_rate, index,
     )
 
-    if process_func == signal_no_value:
-        print(result)
-        assert True
-
     expected = []
     for start, end in index:
         expected.append(


### PR DESCRIPTION
Closes #47 

Alternative implementation to https://github.com/audeering/audinterface/pull/49

This raises an error if the length of the returned sequence of the process function does not match the number of segments for `audinterafce.ProcessWithContext`.

![image](https://user-images.githubusercontent.com/173624/175022771-01d22319-d1ad-494d-8e54-7f7565952b9e.png)

![image](https://user-images.githubusercontent.com/173624/175022815-35b91a00-451b-419c-ad7a-9e60cb2533e1.png)
