### PR TITLE
Add min_signal_dur, max_signal_dur arguments

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -86,16 +86,24 @@ class Feature:
             Afterwards processing is applied to each segment
         keep_nat: if the end of segment is set to ``NaT`` do not replace
             with file duration in the result
-        min_signal_length: minimum signal length
+        min_signal_dur: minimum signal duration
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
+            To specify a unit provide as string,
+            e.g. ``'2ms'``.
+            To specify in samples provide as string without unit,
+            e.g. ``'2000'``
             If provided signal is shorter,
             it will be zero padded at the end
-        max_signal_length: maximum signal length
+        max_signal_dur: maximum signal duraton
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
+            To specify a unit provide as string,
+            e.g. ``'2ms'``.
+            To specify in samples provide as string without unit,
+            e.g. ``'2000'``
             If provided signal is longer,
             it will be cut at the end
         num_workers: number of parallel jobs or 1 for sequential
@@ -155,8 +163,8 @@ class Feature:
             mixdown: bool = False,
             segment: Segment = None,
             keep_nat: bool = False,
-            min_signal_length: Timestamp = None,
-            max_signal_length: Timestamp = None,
+            min_signal_dur: Timestamp = None,
+            max_signal_dur: Timestamp = None,
             num_workers: typing.Optional[int] = 1,
             multiprocessing: bool = False,
             verbose: bool = False,
@@ -227,8 +235,8 @@ class Feature:
             channels=channels,
             mixdown=mixdown,
             segment=segment,
-            min_signal_length=min_signal_length,
-            max_signal_length=max_signal_length,
+            min_signal_dur=min_signal_dur,
+            max_signal_dur=max_signal_dur,
             keep_nat=keep_nat,
             num_workers=num_workers,
             multiprocessing=multiprocessing,

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -86,12 +86,16 @@ class Feature:
             Afterwards processing is applied to each segment
         keep_nat: if the end of segment is set to ``NaT`` do not replace
             with file duration in the result
-        min_signal_length: minimum signal length in samples
+        min_signal_length: minimum signal length
             required by ``process_func``.
+            If value is as a float or integer
+            it is treated as seconds.
             If provided signal is shorter,
             it will be zero padded at the end
-        max_signal_length: maximum signal length in samples
+        max_signal_length: maximum signal length
             required by ``process_func``.
+            If value is as a float or integer
+            it is treated as seconds.
             If provided signal is longer,
             it will be cut at the end
         num_workers: number of parallel jobs or 1 for sequential
@@ -151,8 +155,8 @@ class Feature:
             mixdown: bool = False,
             segment: Segment = None,
             keep_nat: bool = False,
-            min_signal_length: int = None,
-            max_signal_length: int = None,
+            min_signal_length: Timestamp = None,
+            max_signal_length: Timestamp = None,
             num_workers: typing.Optional[int] = 1,
             multiprocessing: bool = False,
             verbose: bool = False,

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -86,6 +86,14 @@ class Feature:
             Afterwards processing is applied to each segment
         keep_nat: if the end of segment is set to ``NaT`` do not replace
             with file duration in the result
+        min_signal_length: minimum signal length in samples
+            required by ``process_func``.
+            If provided signal is shorter,
+            it will be zero padded at the end
+        max_signal_length: maximum signal length in samples
+            required by ``process_func``.
+            If provided signal is longer,
+            it will be cut at the end
         num_workers: number of parallel jobs or 1 for sequential
             processing. If ``None`` will be set to the number of
             processors on the machine multiplied by 5 in case of
@@ -143,6 +151,8 @@ class Feature:
             mixdown: bool = False,
             segment: Segment = None,
             keep_nat: bool = False,
+            min_signal_length: int = None,
+            max_signal_length: int = None,
             num_workers: typing.Optional[int] = 1,
             multiprocessing: bool = False,
             verbose: bool = False,
@@ -213,6 +223,8 @@ class Feature:
             channels=channels,
             mixdown=mixdown,
             segment=segment,
+            min_signal_length=min_signal_length,
+            max_signal_length=max_signal_length,
             keep_nat=keep_nat,
             num_workers=num_workers,
             multiprocessing=multiprocessing,

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -452,11 +452,21 @@ class Process:
                 self.max_signal_length is not None
                 and num_samples > self.max_signal_length
         ):
+            length = pd.to_timedelta(
+                self.max_signal_length / sampling_rate,
+                unit='s',
+            )
+            end = start + length
             signal = signal[:, :self.max_signal_length]
         if (
                 self.min_signal_length is not None
                 and num_samples < self.min_signal_length
         ):
+            length = pd.to_timedelta(
+                self.min_signal_length / sampling_rate,
+                unit='s',
+            )
+            end = start + length
             num_pad = self.min_signal_length - num_samples
             signal = np.pad(signal, ((0, 0), (0, num_pad)), 'constant')
 

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -42,6 +42,14 @@ class Process:
             Afterwards processing is applied to each segment
         keep_nat: if the end of segment is set to ``NaT`` do not replace
             with file duration in the result
+        min_signal_length: minimum signal length in samples
+            required by ``process_func``.
+            If provided signal is shorter,
+            it will be zero padded at the end
+        max_signal_length: maximum signal length in samples
+            required by ``process_func``.
+            If provided signal is longer,
+            it will be cut at the end
         num_workers: number of parallel jobs or 1 for sequential
             processing. If ``None`` will be set to the number of
             processors on the machine multiplied by 5 in case of
@@ -91,6 +99,8 @@ class Process:
             mixdown: bool = False,
             segment: Segment = None,
             keep_nat: bool = False,
+            min_signal_length: int = None,
+            max_signal_length: int = None,
             num_workers: typing.Optional[int] = 1,
             multiprocessing: bool = False,
             verbose: bool = False,
@@ -112,6 +122,10 @@ class Process:
         r"""Segmentation object."""
         self.keep_nat = keep_nat
         r"""Keep NaT in results."""
+        self.min_signal_length = min_signal_length
+        r"""Minimum signal length."""
+        self.max_signal_length = max_signal_length
+        r"""Maximum signal length."""
         self.num_workers = num_workers
         r"""Number of workers."""
         self.multiprocessing = multiprocessing
@@ -431,8 +445,23 @@ class Process:
             signal, sampling_rate, start, end,
         )
 
-        # Trim and process signal
-        y = self(signal[:, start_i:end_i], sampling_rate)
+        # Trim signal and ensure it has requested min/max length
+        signal = signal[:, start_i:end_i]
+        num_samples = signal.shape[1]
+        if (
+                self.max_signal_length is not None
+                and num_samples > self.max_signal_length
+        ):
+            signal = signal[:, :self.max_signal_length]
+        if (
+                self.min_signal_length is not None
+                and num_samples < self.min_signal_length
+        ):
+            num_pad = self.min_signal_length - num_samples
+            signal = np.pad(signal, ((0, 0), (0, num_pad)), 'constant')
+
+        # Process signal
+        y = self(signal, sampling_rate)
 
         # Create index
         if file is not None:

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -120,16 +120,24 @@ class Segment:
         mixdown: apply mono mix-down on selection
         keep_nat: if the end of segment is set to ``NaT`` do not replace
             with file duration in the result
-        min_signal_length: minimum signal length
+        min_signal_dur: minimum signal length
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
+            To specify a unit provide as string,
+            e.g. ``'2ms'``.
+            To specify in samples provide as string without unit,
+            e.g. ``'2000'``
             If provided signal is shorter,
             it will be zero padded at the end
-        max_signal_length: maximum signal length
+        max_signal_dur: maximum signal length
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
+            To specify a unit provide as string,
+            e.g. ``'2ms'``.
+            To specify in samples provide as string without unit,
+            e.g. ``'2000'``
             If provided signal is longer,
             it will be cut at the end
         num_workers: number of parallel jobs or 1 for sequential
@@ -194,8 +202,8 @@ class Segment:
             channels: typing.Union[int, typing.Sequence[int]] = None,
             mixdown: bool = False,
             keep_nat: bool = False,
-            min_signal_length: Timestamp = None,
-            max_signal_length: Timestamp = None,
+            min_signal_dur: Timestamp = None,
+            max_signal_dur: Timestamp = None,
             num_workers: typing.Optional[int] = 1,
             multiprocessing: bool = False,
             verbose: bool = False,
@@ -224,8 +232,8 @@ class Segment:
             channels=channels,
             mixdown=mixdown,
             keep_nat=keep_nat,
-            min_signal_length=min_signal_length,
-            max_signal_length=max_signal_length,
+            min_signal_dur=min_signal_dur,
+            max_signal_dur=max_signal_dur,
             num_workers=num_workers,
             multiprocessing=multiprocessing,
             verbose=verbose,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -120,12 +120,16 @@ class Segment:
         mixdown: apply mono mix-down on selection
         keep_nat: if the end of segment is set to ``NaT`` do not replace
             with file duration in the result
-        min_signal_length: minimum signal length in samples
+        min_signal_length: minimum signal length
             required by ``process_func``.
+            If value is as a float or integer
+            it is treated as seconds.
             If provided signal is shorter,
             it will be zero padded at the end
-        max_signal_length: maximum signal length in samples
+        max_signal_length: maximum signal length
             required by ``process_func``.
+            If value is as a float or integer
+            it is treated as seconds.
             If provided signal is longer,
             it will be cut at the end
         num_workers: number of parallel jobs or 1 for sequential
@@ -190,8 +194,8 @@ class Segment:
             channels: typing.Union[int, typing.Sequence[int]] = None,
             mixdown: bool = False,
             keep_nat: bool = False,
-            min_signal_length: int = None,
-            max_signal_length: int = None,
+            min_signal_length: Timestamp = None,
+            max_signal_length: Timestamp = None,
             num_workers: typing.Optional[int] = 1,
             multiprocessing: bool = False,
             verbose: bool = False,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -120,6 +120,14 @@ class Segment:
         mixdown: apply mono mix-down on selection
         keep_nat: if the end of segment is set to ``NaT`` do not replace
             with file duration in the result
+        min_signal_length: minimum signal length in samples
+            required by ``process_func``.
+            If provided signal is shorter,
+            it will be zero padded at the end
+        max_signal_length: maximum signal length in samples
+            required by ``process_func``.
+            If provided signal is longer,
+            it will be cut at the end
         num_workers: number of parallel jobs or 1 for sequential
             processing. If ``None`` will be set to the number of
             processors on the machine multiplied by 5 in case of
@@ -182,6 +190,8 @@ class Segment:
             channels: typing.Union[int, typing.Sequence[int]] = None,
             mixdown: bool = False,
             keep_nat: bool = False,
+            min_signal_length: int = None,
+            max_signal_length: int = None,
             num_workers: typing.Optional[int] = 1,
             multiprocessing: bool = False,
             verbose: bool = False,
@@ -210,6 +220,8 @@ class Segment:
             channels=channels,
             mixdown=mixdown,
             keep_nat=keep_nat,
+            min_signal_length=min_signal_length,
+            max_signal_length=max_signal_length,
             num_workers=num_workers,
             multiprocessing=multiprocessing,
             verbose=verbose,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -10,7 +10,7 @@ import audinterface
 import audformat
 
 
-def signal_dur(signal, sampling_rate):
+def signal_duration(signal, sampling_rate):
     return signal.shape[1] / sampling_rate
 
 
@@ -150,7 +150,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             marks=pytest.mark.xfail(raises=ValueError),
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -162,7 +162,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             3.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -174,7 +174,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             3.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -186,7 +186,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             3.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -198,7 +198,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             2.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -210,7 +210,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             2.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -222,7 +222,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             2.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -234,7 +234,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             2.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -246,7 +246,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -258,7 +258,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -270,7 +270,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -282,7 +282,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -352,7 +352,7 @@ def test_process_file(
     'expected_output',
     [
         (
-            signal_dur,
+            signal_duration,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -361,7 +361,7 @@ def test_process_file(
             [3.0] * 2,
         ),
         (
-            signal_dur,
+            signal_duration,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -370,7 +370,7 @@ def test_process_file(
             [1.0] * 2,
         ),
         (
-            signal_dur,
+            signal_duration,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -379,7 +379,7 @@ def test_process_file(
             [1.0] * 2,
         ),
         (
-            signal_dur,
+            signal_duration,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -388,7 +388,7 @@ def test_process_file(
             [3.0, 1.0],
         ),
         (
-            signal_dur,
+            signal_duration,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -397,7 +397,7 @@ def test_process_file(
             [3.0, 1.0],
         ),
         (
-            signal_dur,
+            signal_duration,
             3,
             np.zeros((1, 24000)),
             8000,
@@ -406,7 +406,7 @@ def test_process_file(
             [3.0, 1.0],
         ),
         (
-            signal_dur,
+            signal_duration,
             1,
             np.zeros((1, 24000)),
             8000,
@@ -706,7 +706,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             3.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -718,7 +718,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -730,7 +730,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -742,7 +742,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -754,7 +754,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             3.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -766,7 +766,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             3.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -778,7 +778,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -790,7 +790,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -802,7 +802,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -814,7 +814,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_dur,
+            signal_duration,
             {},
             None,
             np.array([1., 2., 3.]),

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1044,6 +1044,70 @@ def test_process_signal_from_index(
 
 
 @pytest.mark.parametrize(
+    'process_func, signal, sampling_rate, min_signal_length, '
+    'max_signal_length, expected',
+    [
+        (
+            None,
+            np.ones((1, 44100)),
+            44100,
+            None,
+            None,
+            np.ones((1, 44100)),
+        ),
+        (
+            None,
+            np.ones((1, 44100)),
+            44100,
+            48000,
+            None,
+            np.concatenate(
+                [
+                    np.ones((1, 44100)),
+                    np.zeros((1, (48000 - 44100))),
+                ],
+                axis=1,
+            ),
+        ),
+        (
+            None,
+            np.ones((1, 44100)),
+            44100,
+            None,
+            100,
+            np.ones((1, 100)),
+        ),
+    ]
+)
+def test_process_signal_min_max(
+        process_func,
+        signal,
+        sampling_rate,
+        min_signal_length,
+        max_signal_length,
+        expected,
+):
+    process = audinterface.Process(
+        process_func=process_func,
+        sampling_rate=None,
+        resample=False,
+        min_signal_length=min_signal_length,
+        max_signal_length=max_signal_length,
+        verbose=False,
+    )
+    result = process.process_signal(signal, sampling_rate)
+    print(result)
+    expected = pd.Series(
+        [expected],
+        index=audinterface.utils.signal_index(
+            pd.to_timedelta(0),
+            pd.to_timedelta(expected.shape[1] / sampling_rate, unit='s'),
+        )
+    )
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
     'segment',
     [
         audinterface.Segment(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -10,7 +10,7 @@ import audinterface
 import audformat
 
 
-def signal_duration(signal, sampling_rate):
+def signal_dur(signal, sampling_rate):
     return signal.shape[1] / sampling_rate
 
 
@@ -150,7 +150,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             marks=pytest.mark.xfail(raises=ValueError),
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -162,7 +162,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             3.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -174,7 +174,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             3.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -186,7 +186,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             3.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -198,7 +198,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             2.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -210,7 +210,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             2.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -222,7 +222,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             2.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -234,7 +234,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             2.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -246,7 +246,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -258,7 +258,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -270,7 +270,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -282,7 +282,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             None,
             np.zeros((1, 24000)),
             8000,
@@ -352,7 +352,7 @@ def test_process_file(
     'expected_output',
     [
         (
-            signal_duration,
+            signal_dur,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -361,7 +361,7 @@ def test_process_file(
             [3.0] * 2,
         ),
         (
-            signal_duration,
+            signal_dur,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -370,7 +370,7 @@ def test_process_file(
             [1.0] * 2,
         ),
         (
-            signal_duration,
+            signal_dur,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -379,7 +379,7 @@ def test_process_file(
             [1.0] * 2,
         ),
         (
-            signal_duration,
+            signal_dur,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -388,7 +388,7 @@ def test_process_file(
             [3.0, 1.0],
         ),
         (
-            signal_duration,
+            signal_dur,
             2,
             np.zeros((1, 24000)),
             8000,
@@ -397,7 +397,7 @@ def test_process_file(
             [3.0, 1.0],
         ),
         (
-            signal_duration,
+            signal_dur,
             3,
             np.zeros((1, 24000)),
             8000,
@@ -406,7 +406,7 @@ def test_process_file(
             [3.0, 1.0],
         ),
         (
-            signal_duration,
+            signal_dur,
             1,
             np.zeros((1, 24000)),
             8000,
@@ -706,7 +706,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             3.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -718,7 +718,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -730,7 +730,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -742,7 +742,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -754,7 +754,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             3.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -766,7 +766,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             3.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -778,7 +778,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -790,7 +790,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -802,7 +802,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -814,7 +814,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
             1.0,
         ),
         (
-            signal_duration,
+            signal_dur,
             {},
             None,
             np.array([1., 2., 3.]),
@@ -1044,8 +1044,8 @@ def test_process_signal_from_index(
 
 
 @pytest.mark.parametrize(
-    'process_func, signal, sampling_rate, min_signal_length, '
-    'max_signal_length, expected',
+    'process_func, signal, sampling_rate, min_signal_dur, '
+    'max_signal_dur, expected',
     [
         (
             None,
@@ -1083,16 +1083,16 @@ def test_process_signal_min_max(
         process_func,
         signal,
         sampling_rate,
-        min_signal_length,
-        max_signal_length,
+        min_signal_dur,
+        max_signal_dur,
         expected,
 ):
     process = audinterface.Process(
         process_func=process_func,
         sampling_rate=None,
         resample=False,
-        min_signal_length=min_signal_length,
-        max_signal_length=max_signal_length,
+        min_signal_dur=min_signal_dur,
+        max_signal_dur=max_signal_dur,
         verbose=False,
     )
     result = process.process_signal(signal, sampling_rate)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1059,12 +1059,12 @@ def test_process_signal_from_index(
             None,
             np.ones((1, 44100)),
             44100,
-            48000,
+            2,
             None,
             np.concatenate(
                 [
                     np.ones((1, 44100)),
-                    np.zeros((1, (48000 - 44100))),
+                    np.zeros((1, 44100)),
                 ],
                 axis=1,
             ),
@@ -1074,8 +1074,8 @@ def test_process_signal_from_index(
             np.ones((1, 44100)),
             44100,
             None,
-            100,
-            np.ones((1, 100)),
+            0.01,
+            np.ones((1, 441)),
         ),
     ]
 )
@@ -1096,7 +1096,6 @@ def test_process_signal_min_max(
         verbose=False,
     )
     result = process.process_signal(signal, sampling_rate)
-    print(result)
     expected = pd.Series(
         [expected],
         index=audinterface.utils.signal_index(


### PR DESCRIPTION
Closes #41 

This adds the arguments `min_signal_dur` and `max_signal_dur` to `audinterface.Process`, `audinterface.Feature`, and `audinterface.Segment`, but not to `audinterafce.ProcessWithContext` as there the process function should take care itself about it.

The signal is cut at the end or zero padded at the end to fullfill the requested requirements.

If both arguments are given it is not checked if `max_signal_dur` > `min_signal_dur`, but `max_signal_dur` is always applied first.

![image](https://user-images.githubusercontent.com/173624/175531028-72daa072-5d85-4246-8961-3b1443be9f58.png)
