### PR TITLE
Deprecate unit, specify samples as string

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -154,6 +154,22 @@ class Feature:
     ):
         feature_names = audeer.to_list(feature_names)
 
+        # ------
+        # Handle deprecated 'unit' keyword argument
+        def add_unit(dur, unit):
+            if unit == 'samples':
+                return str(dur)
+            else:
+                return f'{dur}{unit}'
+
+        if 'unit' in kwargs:
+            unit = kwargs['unit']
+            if win_dur is not None:
+                win_dur = add_unit(win_dur, unit)
+            if hop_dur is not None:
+                hop_dur = add_unit(hop_dur, unit)
+        # ------
+
         process_func_args = process_func_args or {}
         if kwargs:
             warnings.warn(

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -162,6 +162,8 @@ class Feature:
             message = (
                 "'unit' argument is deprecated "
                 "and will be removed with version '1.2.0'."
+                "The unit can now directly specified "
+                "within the 'win_dur' and 'hop_dur' arguments."
             )
             warnings.warn(
                 message,

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -67,7 +67,7 @@ class Feature:
             To specify a unit provide as string,
             e.g. ``'2ms'``.
             To specify in samples provide as string without unit,
-            e.g. ``2000``
+            e.g. ``'2000'``
         hop_dur: hop size,
             if features are extracted with a sliding window.
             This defines the shift between two windows.
@@ -76,7 +76,7 @@ class Feature:
             To specify a unit provide as string,
             e.g. ``'2ms'``.
             To specify in samples provide a string without unit,
-            e.g. ``2000``.
+            e.g. ``'2000'``.
             Defaults to ``win_dur / 2``
         resample: if ``True`` enforces given sampling rate by resampling
         channels: channel selection, see :func:`audresample.remix`
@@ -243,13 +243,13 @@ class Feature:
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
             root: root folder to expand relative file path
 
         Raises:
@@ -284,14 +284,14 @@ class Feature:
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``.
+                e.g. ``'2000'``.
                 If a scalar is given, it is applied to all files
             ends: segment end positions.
                 Time values given as float or integers are treated as seconds
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``.
+                e.g. ``'2000'``.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
 
@@ -421,13 +421,13 @@ class Feature:
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
 
         Raises:
             RuntimeError: if sampling rates do not match

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -126,10 +126,6 @@ class Feature:
         wav/03a01Fa.wav 0 days 0 days 00:00:01.898250 -0.000311  0.082317
 
     """
-    @audeer.deprecated_keyword_argument(
-        deprecated_argument='unit',
-        removal_version='1.2.0',
-    )
     def __init__(
             self,
             feature_names: typing.Union[str, typing.Sequence[str]],
@@ -163,7 +159,16 @@ class Feature:
                 return f'{dur}{unit}'
 
         if 'unit' in kwargs:
-            unit = kwargs['unit']
+            message = (
+                "'unit' argument is deprecated "
+                "and will be removed with version '1.2.0'."
+            )
+            warnings.warn(
+                message,
+                category=UserWarning,
+                stacklevel=2,
+            )
+            unit = kwargs.pop('unit')
             if win_dur is not None:
                 win_dur = add_unit(win_dur, unit)
             if hop_dur is not None:

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -182,9 +182,17 @@ class Process:
         Args:
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds
+                If value is as a float or integer it is treated as seconds.
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds
+                If value is as a float or integer it is treated as seconds.
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``
             root: root folder to expand relative file path
 
         Returns:
@@ -197,8 +205,6 @@ class Process:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        start = utils.to_timedelta(start)
-        end = utils.to_timedelta(end)
         if self.segment is not None:
             index = self.segment.process_file(
                 file,
@@ -208,6 +214,8 @@ class Process:
             )
             return self._process_index_wo_segment(index, root)
         else:
+            start = utils.to_timedelta(start, self.sampling_rate)
+            end = utils.to_timedelta(end, self.sampling_rate)
             return self._process_file(file, start=start, end=end, root=root)
 
     def process_files(
@@ -224,9 +232,17 @@ class Process:
             files: list of file paths
             starts: segment start positions.
                 Time values given as float or integers are treated as seconds.
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``.
                 If a scalar is given, it is applied to all files
             ends: segment end positions.
                 Time values given as float or integers are treated as seconds
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
 
@@ -247,9 +263,6 @@ class Process:
             starts = [starts] * len(files)
         if isinstance(ends, (type(None), float, int, str, pd.Timedelta)):
             ends = [ends] * len(files)
-
-        starts = utils.to_timedelta(starts)
-        ends = utils.to_timedelta(ends)
 
         params = [
             (
@@ -448,9 +461,17 @@ class Process:
             sampling_rate: sampling rate in Hz
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds
+                If value is as a float or integer it is treated as seconds.
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``
+                If value is as a float or integer it is treated as seconds.
 
         Returns:
             Series with processed signal conform to audformat_
@@ -462,8 +483,6 @@ class Process:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        start = utils.to_timedelta(start)
-        end = utils.to_timedelta(end)
         if self.segment is not None:
             index = self.segment.process_signal(
                 signal,
@@ -478,6 +497,8 @@ class Process:
                 index,
             )
         else:
+            start = utils.to_timedelta(start, sampling_rate)
+            end = utils.to_timedelta(end, sampling_rate)
             return self._process_signal(
                 signal,
                 sampling_rate,

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -186,13 +186,13 @@ class Process:
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
             root: root folder to expand relative file path
 
         Returns:
@@ -235,14 +235,14 @@ class Process:
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``.
+                e.g. ``'2000'``.
                 If a scalar is given, it is applied to all files
             ends: segment end positions.
                 Time values given as float or integers are treated as seconds
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``.
+                e.g. ``'2000'``.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
 
@@ -465,12 +465,12 @@ class Process:
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
             end: end processing at this position.
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
                 If value is as a float or integer it is treated as seconds.
 
         Returns:

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -233,13 +233,13 @@ class Segment:
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
             root: root folder to expand relative file path
 
         Returns:
@@ -291,14 +291,14 @@ class Segment:
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``.
+                e.g. ``'2000'``.
                 If a scalar is given, it is applied to all files
             ends: segment end positions.
                 Time values given as float or integers are treated as seconds
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``.
+                e.g. ``'2000'``.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
 
@@ -433,13 +433,13 @@ class Segment:
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
                 To specify a unit provide as string,
                 e.g. ``'2ms'``.
                 To specify in samples provide as string without unit,
-                e.g. ``2000``
+                e.g. ``'2000'``
 
         Returns:
             Segmented index conform to audformat_

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -229,9 +229,17 @@ class Segment:
         Args:
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds
+                If value is as a float or integer it is treated as seconds.
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds
+                If value is as a float or integer it is treated as seconds.
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``
             root: root folder to expand relative file path
 
         Returns:
@@ -280,9 +288,17 @@ class Segment:
             files: list of file paths
             starts: segment start positions.
                 Time values given as float or integers are treated as seconds.
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``.
                 If a scalar is given, it is applied to all files
             ends: segment end positions.
                 Time values given as float or integers are treated as seconds
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
 
@@ -413,9 +429,17 @@ class Segment:
             sampling_rate: sampling rate in Hz
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds
+                If value is as a float or integer it is treated as seconds.
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds
+                If value is as a float or integer it is treated as seconds.
+                To specify a unit provide as string,
+                e.g. ``'2ms'``.
+                To specify in samples provide as string without unit,
+                e.g. ``2000``
 
         Returns:
             Segmented index conform to audformat_

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -312,7 +312,7 @@ def to_timedelta(
                     raise ValueError(
                         "You have to provide 'sampling_rate' "
                         "when specifying the duration in samples "
-                        "as you did with '{time}'"
+                        f"as you did with '{time}'."
                     )
                 time = int(time) / sampling_rate
         return time

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import audeer
 import audformat
 import audinterface
 import audiofile as af
@@ -33,19 +34,29 @@ def features_extractor_sliding_window(signal, _, hop_size):
     return np.ones((NUM_CHANNELS, NUM_FEATURES, num_time_steps))
 
 
+def test_deprecated_unit_argument():
+    if (
+            audeer.LooseVersion(audinterface.__version__)
+            < audeer.LooseVersion('1.2.0')
+    ):
+        with pytest.warns(UserWarning, match='is deprecated'):
+            audinterface.Feature(['a'], unit='samples')
+    else:
+        with pytest.raises(TypeError, match='unexpected keyword argument'):
+            audinterface.Feature(['a'], unit='samples')
+
+
 def test_feature():
-    # You have to specify sampling rate with unit == 'samples' and win_dur
+    # You have to specify sampling rate when win_dur is in samples
     with pytest.raises(ValueError):
         audinterface.Feature(
             feature_names=('o1', 'o2', 'o3'),
             sampling_rate=None,
-            unit='samples',
-            win_dur=2048,
+            win_dur='2048',
         )
     # If no win_dur is given, no error should occur
     audinterface.Feature(
         feature_names=('o1', 'o2', 'o3'),
-        unit='samples',
         sampling_rate=None,
     )
     # Only hop_dur is given
@@ -56,8 +67,7 @@ def test_feature():
         )
     audinterface.Feature(
         feature_names=('o1', 'o2', 'o3'),
-        win_dur=2048,
-        unit='samples',
+        win_dur='2048',
         sampling_rate=8000,
     )
 
@@ -824,20 +834,20 @@ def test_process_index(tmpdir):
 
 
 @pytest.mark.parametrize(
-    'win_dur, hop_dur, unit',
+    'win_dur, hop_dur',
     [
-        (1, 0.5, 'seconds'),
-        (1, None, 'seconds'),
-        (16000, None, 'samples'),
-        (1000, 500, 'milliseconds'),
-        (SAMPLING_RATE, SAMPLING_RATE // 2, 'samples'),
+        (1, 0.5),
+        (1, None),
+        ('16000', None),
+        ('1000ms', '500ms'),
+        (f'{SAMPLING_RATE}', f'{SAMPLING_RATE // 2}'),
         pytest.param(  # multiple frames, but win_dur is None
-            None, None, 'seconds',
+            None, None,
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),
     ],
 )
-def test_signal_sliding_window(win_dur, hop_dur, unit):
+def test_signal_sliding_window(win_dur, hop_dur):
     # Test sliding window with two time steps
     expected_features = np.ones((NUM_CHANNELS, 2 * NUM_FEATURES))
     extractor = audinterface.Feature(
@@ -850,7 +860,6 @@ def test_signal_sliding_window(win_dur, hop_dur, unit):
         win_dur=win_dur,
         hop_dur=hop_dur,
         sampling_rate=SAMPLING_RATE,
-        unit=unit,
     )
     features = extractor.process_signal(
         SIGNAL_2D,
@@ -858,20 +867,32 @@ def test_signal_sliding_window(win_dur, hop_dur, unit):
     )
     n_time_steps = len(features)
 
-    if unit == 'samples':
-        win_dur = win_dur / SAMPLING_RATE
-        if hop_dur is not None:
-            hop_dur /= SAMPLING_RATE
-        unit = 'seconds'
+    if isinstance(win_dur, str):
+        if all(s.isdigit() for s in win_dur):
+            # samples
+            win_dur = pd.to_timedelta(int(win_dur) / SAMPLING_RATE, unit='s')
+        else:
+            win_dur = pd.to_timedelta(win_dur)
+    else:
+        win_dur = pd.to_timedelta(win_dur, unit='s')
+
     if hop_dur is None:
         hop_dur = win_dur / 2
+    elif isinstance(hop_dur, str):
+        if all(s.isdigit() for s in hop_dur):
+            # samples
+            hop_dur = pd.to_timedelta(int(hop_dur) / SAMPLING_RATE, unit='s')
+        else:
+            hop_dur = pd.to_timedelta(hop_dur)
+    else:
+        hop_dur = pd.to_timedelta(hop_dur, unit='s')
 
     starts = pd.timedelta_range(
         pd.to_timedelta(0),
-        freq=pd.to_timedelta(hop_dur, unit=unit),
+        freq=hop_dur,
         periods=n_time_steps,
     )
-    ends = starts + pd.to_timedelta(win_dur, unit=unit)
+    ends = starts + win_dur
 
     index = audinterface.utils.signal_index(starts, ends)
     pd.testing.assert_frame_equal(

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -40,7 +40,20 @@ def test_deprecated_unit_argument():
             < audeer.LooseVersion('1.2.0')
     ):
         with pytest.warns(UserWarning, match='is deprecated'):
-            audinterface.Feature(['a'], unit='samples')
+            interface = audinterface.Feature(
+                ['a'],
+                win_dur=1000,
+                unit='samples',
+            )
+            assert interface.win_dur == '1000'
+            interface = audinterface.Feature(
+                ['a'],
+                win_dur=1000,
+                hop_dur=500,
+                unit='milliseconds',
+            )
+            assert interface.win_dur == '1000milliseconds'
+            assert interface.hop_dur == '500milliseconds'
     else:
         with pytest.raises(TypeError, match='unexpected keyword argument'):
             audinterface.Feature(['a'], unit='samples')
@@ -840,6 +853,7 @@ def test_process_index(tmpdir):
         (pd.to_timedelta(1, unit='s'), None),
         ('16000', None),
         ('1000ms', '500ms'),
+        ('1000milliseconds', '500milliseconds'),
         (f'{SAMPLING_RATE}', f'{SAMPLING_RATE // 2}'),
         pytest.param(  # multiple frames, but win_dur is None
             None, None,

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -44,6 +44,7 @@ def test_deprecated_unit_argument():
                 ['a'],
                 win_dur=1000,
                 unit='samples',
+                sampling_rate=16000,
             )
             assert interface.win_dur == '1000'
             interface = audinterface.Feature(

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -837,7 +837,7 @@ def test_process_index(tmpdir):
     'win_dur, hop_dur',
     [
         (1, 0.5),
-        (1, None),
+        (pd.to_timedelta(1, unit='s'), None),
         ('16000', None),
         ('1000ms', '500ms'),
         (f'{SAMPLING_RATE}', f'{SAMPLING_RATE // 2}'),


### PR DESCRIPTION
As proposed in https://github.com/audeering/audinterface/pull/52#issuecomment-1164249905 this uses the same time format for `start`, `end`, `win_dur`, `hop_dur` and allows specifying of samples with a string, e.g. `'44100'`.
The `unit` argument of `audinterafce.Feature` was deprecated as it is no longer needed.

![image](https://user-images.githubusercontent.com/173624/175304239-a0b27574-7cfb-481e-9b19-dde0bc386c91.png)

![image](https://user-images.githubusercontent.com/173624/175304175-644f228d-6447-4e48-a09c-179e45c4963e.png)

![image](https://user-images.githubusercontent.com/173624/175304355-387dda3e-a139-48d3-9f1c-dd21a906849f.png)
