### PR TITLE
Remove deprecated kwargs for process_func_args

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -328,16 +328,6 @@ class Feature:
                     dtype=object,
                 )
 
-        process_func_args = process_func_args or {}
-        if kwargs:
-            warnings.warn(
-                utils.kwargs_deprecation_warning,
-                category=UserWarning,
-                stacklevel=2,
-            )
-            for key, value in kwargs.items():
-                process_func_args[key] = value
-
         if win_dur is None and hop_dur is not None:
             raise ValueError(
                 "You have to specify 'win_dur' if 'hop_dur' is given."
@@ -347,6 +337,7 @@ class Feature:
 
         # add 'win_dur' and 'hop_dur' to process_func_args
         # if expected by function but not yet set
+        process_func_args = process_func_args or {}
         signature = inspect.signature(process_func)
         if (
             'win_dur' in signature.parameters

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -3,7 +3,6 @@ import inspect
 import itertools
 import os
 import typing
-import warnings
 
 import numpy as np
 import pandas as pd

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -153,7 +153,6 @@ class Process:
             num_workers: typing.Optional[int] = 1,
             multiprocessing: bool = False,
             verbose: bool = False,
-            **kwargs,
     ):
         if channels is not None:
             channels = audeer.to_list(channels)
@@ -161,16 +160,6 @@ class Process:
         if process_func is None:
             def process_func(signal, _):
                 return signal
-
-        process_func_args = process_func_args or {}
-        if kwargs:
-            warnings.warn(
-                utils.kwargs_deprecation_warning,
-                category=UserWarning,
-                stacklevel=2,
-            )
-            for key, value in kwargs.items():
-                process_func_args[key] = value
 
         if resample and sampling_rate is None:
             raise ValueError(
@@ -187,6 +176,7 @@ class Process:
         # figure out if special arguments
         # to pass to the processing function
         signature = inspect.signature(process_func)
+        process_func_args = process_func_args or {}
         self._process_func_special_args = {
             'idx': False,
             'root': False,

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -2,7 +2,6 @@ import collections
 import inspect
 import itertools
 import typing
-import warnings
 
 import numpy as np
 import pandas as pd

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -105,7 +105,6 @@ class ProcessWithContext:
             channels: typing.Union[int, typing.Sequence[int]] = None,
             mixdown: bool = False,
             verbose: bool = False,
-            **kwargs,
     ):
         if channels is not None:
             channels = audeer.to_list(channels)
@@ -116,16 +115,6 @@ class ProcessWithContext:
                     signal[:, start:end] for start, end in zip(starts, ends)
                 ]
 
-        process_func_args = process_func_args or {}
-        if kwargs:
-            warnings.warn(
-                utils.kwargs_deprecation_warning,
-                category=UserWarning,
-                stacklevel=2,
-            )
-            for key, value in kwargs.items():
-                process_func_args[key] = value
-
         if resample and sampling_rate is None:
             raise ValueError(
                 'sampling_rate has to be provided for resample = True.'
@@ -134,6 +123,7 @@ class ProcessWithContext:
         # figure out if special arguments
         # to pass to the processing function
         signature = inspect.signature(process_func)
+        process_func_args = process_func_args or {}
         self._process_func_special_args = {
             'idx': False,
             'root': False,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -1,7 +1,6 @@
 import errno
 import os
 import typing
-import warnings
 
 import numpy as np
 import pandas as pd

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -212,18 +212,7 @@ class Segment:
             num_workers: typing.Optional[int] = 1,
             multiprocessing: bool = False,
             verbose: bool = False,
-            **kwargs,
     ):
-        process_func_args = process_func_args or {}
-        if kwargs:
-            warnings.warn(
-                utils.kwargs_deprecation_warning,
-                category=UserWarning,
-                stacklevel=2,
-            )
-            for key, value in kwargs.items():
-                process_func_args[key] = value
-
         # avoid cycling imports
         from audinterface.core.process import Process
         process = Process(

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -69,13 +69,6 @@ def is_scalar(value: typing.Any) -> bool:
            (isinstance(value, str) or not hasattr(value, '__len__'))
 
 
-kwargs_deprecation_warning = (
-    "The use of **kwargs is deprecated "
-    "and will be removed with version 1.0.0. "
-    "Use 'process_func_args' instead."
-)
-
-
 def preprocess_signal(
         signal: np.ndarray,
         sampling_rate: int,

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -430,13 +430,6 @@ def test_process_func_args():
             'arg2': 'bar',
         }
     )
-    with pytest.warns(UserWarning):
-        audinterface.Feature(
-            feature_names=('o1', 'o2', 'o3'),
-            process_func=process_func,
-            arg1='foo',
-            arg2='bar',
-        )
 
 
 @pytest.mark.parametrize('preserve_index', [False, True])

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -537,13 +537,6 @@ def test_process_func_args():
             'arg2': 'bar',
         }
     )
-    with pytest.warns(UserWarning):
-        audinterface.Process(
-            feature_names=('o1', 'o2', 'o3'),
-            process_func=process_func,
-            arg1='foo',
-            arg2='bar',
-        )
 
 
 @pytest.mark.parametrize('preserve_index', [False, True])

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -31,13 +31,6 @@ def test_process_func_args():
             'arg2': 'bar',
         }
     )
-    with pytest.warns(UserWarning):
-        audinterface.ProcessWithContext(
-            feature_names=('o1', 'o2', 'o3'),
-            process_func=process_func,
-            arg1='foo',
-            arg2='bar',
-        )
 
 
 def test_process_index(tmpdir):

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -325,12 +325,6 @@ def test_process_func_args():
             'arg2': 'bar',
         }
     )
-    with pytest.warns(UserWarning):
-        audinterface.Segment(
-            process_func=segment_func,
-            arg1='foo',
-            arg2='bar',
-        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
When introducing `process_func_args` in version 0.8.0 beginning of the year we stated that it will be removed in version 1.0.0.

As I think we should release the new version as 1.0.0, this removes it.