### PR TITLE
Add audinterface.utils.to_timedelta()

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -94,26 +94,26 @@ class Feature:
         channels: channel selection, see :func:`audresample.remix`
         win_dur: window duration,
             if features are extracted with a sliding window.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options
         hop_dur: hop duration,
             if features are extracted with a sliding window.
             This defines the shift between two windows.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options.
             Defaults to ``win_dur / 2``
         min_signal_dur: minimum signal duration
             required by ``process_func``.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is shorter,
             it will be zero padded at the end
         max_signal_dur: maximum signal duraton
             required by ``process_func``.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is longer,
@@ -349,10 +349,10 @@ class Feature:
         Args:
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             root: root folder to expand relative file path
 
@@ -517,10 +517,10 @@ class Feature:
             sampling_rate: sampling rate in Hz
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
 
         Raises:

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -96,38 +96,26 @@ class Feature:
             if features are extracted with a sliding window.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options
         hop_dur: hop duration,
             if features are extracted with a sliding window.
             This defines the shift between two windows.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide a string without unit,
-            e.g. ``'2000'``.
+            See :func:`audinterface.utils.to_timedelta` for further options.
             Defaults to ``win_dur / 2``
         min_signal_dur: minimum signal duration
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is shorter,
             it will be zero padded at the end
         max_signal_dur: maximum signal duraton
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is longer,
             it will be cut at the end
         mixdown: apply mono mix-down on selection
@@ -362,16 +350,10 @@ class Feature:
             file: file path
             start: start processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
             root: root folder to expand relative file path
 
         Raises:
@@ -403,17 +385,13 @@ class Feature:
             files: list of file paths
             starts: segment start positions.
                 Time values given as float or integers are treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``.
+                See :func:`audinterface.utils.to_timedelta`
+                for further options.
                 If a scalar is given, it is applied to all files
             ends: segment end positions.
-                Time values given as float or integers are treated as seconds
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``.
+                Time values given as float or integers are treated as seconds.
+                See :func:`audinterface.utils.to_timedelta`
+                for further options.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
 
@@ -540,16 +518,10 @@ class Feature:
             file: file path
             start: start processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
 
         Raises:
             RuntimeError: if sampling rates do not match

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -40,38 +40,26 @@ class Process:
             if processing should be applied on a sliding window.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options
         hop_dur: hop duration,
             if processing should be applied on a sliding window.
             This defines the shift between two windows.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide a string without unit,
-            e.g. ``'2000'``.
+            See :func:`audinterface.utils.to_timedelta` for further options.
             Defaults to ``win_dur / 2``
         min_signal_dur: minimum signal length
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is shorter,
             it will be zero padded at the end
         max_signal_dur: maximum signal length
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is longer,
             it will be cut at the end
         segment: when a :class:`audinterface.Segment` object is provided,
@@ -284,16 +272,10 @@ class Process:
             file: file path
             start: start processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
             root: root folder to expand relative file path
 
         Returns:
@@ -333,17 +315,13 @@ class Process:
             files: list of file paths
             starts: segment start positions.
                 Time values given as float or integers are treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``.
+                See :func:`audinterface.utils.to_timedelta`
+                for further options.
                 If a scalar is given, it is applied to all files
             ends: segment end positions.
-                Time values given as float or integers are treated as seconds
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``.
+                Time values given as float or integers are treated as seconds.
+                See :func:`audinterface.utils.to_timedelta`
+                for further options.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
 
@@ -610,16 +588,10 @@ class Process:
             file: file path
             start: start processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
                 If value is as a float or integer it is treated as seconds.
+                See :func:`audinterface.utils.to_timedelta` for further options
 
         Returns:
             Series with processed signal conform to audformat_

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -38,26 +38,26 @@ class Process:
         mixdown: apply mono mix-down on selection
         win_dur: window duration,
             if processing should be applied on a sliding window.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options
         hop_dur: hop duration,
             if processing should be applied on a sliding window.
             This defines the shift between two windows.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options.
             Defaults to ``win_dur / 2``
         min_signal_dur: minimum signal length
             required by ``process_func``.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is shorter,
             it will be zero padded at the end
         max_signal_dur: maximum signal length
             required by ``process_func``.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is longer,
@@ -271,10 +271,10 @@ class Process:
         Args:
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             root: root folder to expand relative file path
 
@@ -587,10 +587,10 @@ class Process:
             sampling_rate: sampling rate in Hz
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
 
         Returns:

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -120,14 +120,14 @@ class Segment:
         mixdown: apply mono mix-down on selection
         min_signal_dur: minimum signal length
             required by ``process_func``.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is shorter,
             it will be zero padded at the end
         max_signal_dur: maximum signal length
             required by ``process_func``.
-            If value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is longer,
@@ -249,10 +249,10 @@ class Segment:
         Args:
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             root: root folder to expand relative file path
 
@@ -439,10 +439,10 @@ class Segment:
             sampling_rate: sampling rate in Hz
             file: file path
             start: start processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
-                If value is as a float or integer it is treated as seconds.
+                If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
 
         Returns:

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -122,20 +122,14 @@ class Segment:
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is shorter,
             it will be zero padded at the end
         max_signal_dur: maximum signal length
             required by ``process_func``.
             If value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options.
             If provided signal is longer,
             it will be cut at the end
         keep_nat: if the end of segment is set to ``NaT`` do not replace
@@ -256,16 +250,10 @@ class Segment:
             file: file path
             start: start processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
             root: root folder to expand relative file path
 
         Returns:
@@ -314,17 +302,13 @@ class Segment:
             files: list of file paths
             starts: segment start positions.
                 Time values given as float or integers are treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``.
+                See :func:`audinterface.utils.to_timedelta`
+                for further options.
                 If a scalar is given, it is applied to all files
             ends: segment end positions.
                 Time values given as float or integers are treated as seconds
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``.
+                See :func:`audinterface.utils.to_timedelta`
+                for further options.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
 
@@ -456,16 +440,10 @@ class Segment:
             file: file path
             start: start processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
             end: end processing at this position.
                 If value is as a float or integer it is treated as seconds.
-                To specify a unit provide as string,
-                e.g. ``'2ms'``.
-                To specify in samples provide as string without unit,
-                e.g. ``'2000'``
+                See :func:`audinterface.utils.to_timedelta` for further options
 
         Returns:
             Segmented index conform to audformat_

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -398,7 +398,7 @@ def to_timedelta(
         durations: Timestamps,
         sampling_rate: int = None,
 ) -> typing.Union[pd.Timedelta, typing.List[pd.Timedelta]]:
-    r"""Convert time value(s) to :class:`pandas.Timedelta`.
+    r"""Convert duration value(s) to :class:`pandas.Timedelta`.
 
     If duration is given as string without unit,
     it is treated as samples

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -403,7 +403,7 @@ def to_array(value: typing.Any) -> np.ndarray:
 def to_timedelta(
         times: Timestamps,
         sampling_rate: int = None,
-) -> typing.Union[pd.Timedelta, typing.Sequence[pd.Timedelta]]:
+) -> typing.Union[pd.Timedelta, typing.Sequence[pd.TimedeltaIndex]]:
     r"""Convert time value to :class:`pandas.Timedelta`.
 
     If time is given as string without unit,
@@ -423,7 +423,7 @@ def to_timedelta(
             if any duration value is provided in samples
 
     Returns:
-        duration values as :class:``pandas.Timedelta`` objects
+        duration values as :class:`pandas.Timedelta` objects
 
     Raises:
         ValueError: if a duration value is given in samples,
@@ -432,14 +432,16 @@ def to_timedelta(
     Example:
         >>> to_timedelta(2)
         Timedelta('0 days 00:00:02')
+        >>> to_timedelta(2.0)
+        Timedelta('0 days 00:00:02')
         >>> to_timedelta('2ms')
         Timedelta('0 days 00:00:00.002000')
         >>> to_timedelta('200milliseconds')
         Timedelta('0 days 00:00:00.200000')
-        >>> to_timedelta('2000', 1000)
-        Timedelta('0 days 00:00:02')
+        >>> to_timedelta([1, '2000'], 1000)
+        TimedeltaIndex(['0 days 00:00:01', '0 days 00:00:02'], dtype='timedelta64[ns]', freq=None)
 
-    """
+    """  # noqa: E501
 
     def convert_samples_to_seconds(time):
         if isinstance(time, str):

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -403,7 +403,7 @@ def to_array(value: typing.Any) -> np.ndarray:
 def to_timedelta(
         times: Timestamps,
         sampling_rate: int = None,
-) -> typing.Union[pd.Timedelta, typing.Sequence[pd.TimedeltaIndex]]:
+) -> typing.Union[pd.Timedelta, pd.TimedeltaIndex]:
     r"""Convert time value to :class:`pandas.Timedelta`.
 
     If time is given as string without unit,

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -404,11 +404,40 @@ def to_timedelta(
         times: Timestamps,
         sampling_rate: int = None,
 ) -> typing.Union[pd.Timedelta, typing.Sequence[pd.Timedelta]]:
-    r"""Convert time value to pd.Timedelta.
+    r"""Convert time value to :class:`pandas.Timedelta`.
 
     If time is given as string without unit,
     it is treated as samples
     and requires that ``'sampling_rate'`` is not ``None``.
+
+    Args:
+        durations: duration value(s).
+            If duration value is as a float or integer
+            it is treated as seconds.
+            To specify a unit provide as string,
+            e.g. ``'2ms'``.
+            To specify in samples provide as string without unit,
+            e.g. ``'2000'``
+        sampling_rate: sampling rate in Hz.
+            Needs to be provided
+            if any duration value is provided in samples
+
+    Returns:
+        duration values as :class:``pandas.Timedelta`` objects
+
+    Raises:
+        ValueError: if a duration value is given in samples,
+            but ``sampling_rate`` is ``None``
+
+    Example:
+        >>> to_timedelta(2)
+        Timedelta('0 days 00:00:02')
+        >>> to_timedelta('2ms')
+        Timedelta('0 days 00:00:00.002000')
+        >>> to_timedelta('200milliseconds')
+        Timedelta('0 days 00:00:00.200000')
+        >>> to_timedelta('2000', 1000)
+        Timedelta('0 days 00:00:02')
 
     """
 

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -401,7 +401,7 @@ def to_array(value: typing.Any) -> np.ndarray:
 
 
 def to_timedelta(
-        times: Timestamps,
+        durations: Timestamps,
         sampling_rate: int = None,
 ) -> typing.Union[pd.Timedelta, pd.TimedeltaIndex]:
     r"""Convert time value to :class:`pandas.Timedelta`.
@@ -459,16 +459,16 @@ def to_timedelta(
         return time
 
     if (
-            not isinstance(times, str)
-            and isinstance(times, collections.abc.Iterable)
+            not isinstance(durations, str)
+            and isinstance(durations, collections.abc.Iterable)
     ):
-        # sequence of time entries
-        times = [convert_samples_to_seconds(t) for t in times]
+        # sequence of duration entries
+        durations = [convert_samples_to_seconds(dur) for dur in durations]
     else:
-        # single time entry
-        times = convert_samples_to_seconds(times)
+        # single duration entry
+        durations = convert_samples_to_seconds(durations)
 
     try:
-        return pd.to_timedelta(times, unit='s')
+        return pd.to_timedelta(durations, unit='s')
     except ValueError:  # catches values like '1s'
-        return pd.to_timedelta(times)
+        return pd.to_timedelta(durations)

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -270,8 +270,8 @@ def signal_index(
 
     index = pd.MultiIndex.from_arrays(
         [
-            to_timedelta(starts),
-            to_timedelta(ends),
+            pd.TimedeltaIndex(to_timedelta(starts)),
+            pd.TimedeltaIndex(to_timedelta(ends)),
         ],
         names=[
             audformat.define.IndexField.START,
@@ -403,7 +403,7 @@ def to_array(value: typing.Any) -> np.ndarray:
 def to_timedelta(
         durations: Timestamps,
         sampling_rate: int = None,
-) -> typing.Union[pd.Timedelta, pd.TimedeltaIndex]:
+) -> typing.Union[pd.Timedelta, typing.List[pd.Timedelta]]:
     r"""Convert time value to :class:`pandas.Timedelta`.
 
     If time is given as string without unit,
@@ -439,7 +439,7 @@ def to_timedelta(
         >>> to_timedelta('200milliseconds')
         Timedelta('0 days 00:00:00.200000')
         >>> to_timedelta([1, '2000'], 1000)
-        TimedeltaIndex(['0 days 00:00:01', '0 days 00:00:02'], dtype='timedelta64[ns]', freq=None)
+        [Timedelta('0 days 00:00:01'), Timedelta('0 days 00:00:02')]
 
     """  # noqa: E501
 
@@ -469,6 +469,11 @@ def to_timedelta(
         durations = convert_samples_to_seconds(durations)
 
     try:
-        return pd.to_timedelta(durations, unit='s')
+        durations = pd.to_timedelta(durations, unit='s')
     except ValueError:  # catches values like '1s'
-        return pd.to_timedelta(durations)
+        durations = pd.to_timedelta(durations)
+
+    if isinstance(durations, pd.TimedeltaIndex):
+        durations = list(durations)
+
+    return durations

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -302,17 +302,11 @@ def sliding_window(
         win_dur: window duration,
             if value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options
         hop_dur: hop duration,
             if value is as a float or integer
             it is treated as seconds.
-            To specify a unit provide as string,
-            e.g. ``'2ms'``.
-            To specify in samples provide as string without unit,
-            e.g. ``'2000'``
+            See :func:`audinterface.utils.to_timedelta` for further options
 
     Returns:
         view of signal with shape ``(channels, samples, frames)``

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -398,15 +398,15 @@ def to_timedelta(
         durations: Timestamps,
         sampling_rate: int = None,
 ) -> typing.Union[pd.Timedelta, typing.List[pd.Timedelta]]:
-    r"""Convert time value to :class:`pandas.Timedelta`.
+    r"""Convert time value(s) to :class:`pandas.Timedelta`.
 
-    If time is given as string without unit,
+    If duration is given as string without unit,
     it is treated as samples
     and requires that ``'sampling_rate'`` is not ``None``.
 
     Args:
         durations: duration value(s).
-            If duration value is as a float or integer
+            If value is a float or integer
             it is treated as seconds.
             To specify a unit provide as string,
             e.g. ``'2ms'``.
@@ -417,7 +417,7 @@ def to_timedelta(
             if any duration value is provided in samples
 
     Returns:
-        duration values as :class:`pandas.Timedelta` objects
+        duration value(s) as :class:`pandas.Timedelta` objects
 
     Raises:
         ValueError: if a duration value is given in samples,

--- a/audinterface/utils/__init__.py
+++ b/audinterface/utils/__init__.py
@@ -2,4 +2,5 @@ from audinterface.core.utils import (
     read_audio,
     signal_index,
     sliding_window,
+    to_timedelta,
 )

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -17,3 +17,8 @@ sliding_window
 --------------
 
 .. autofunction:: sliding_window
+
+to_timedelta
+------------
+
+.. autofunction:: to_timedelta

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -915,10 +915,10 @@ def test_signal_sliding_window(process_func, is_mono, applies_sliding_window,
         )
         n_time_steps = len(df)
 
-        win_dur = audinterface.core.utils.to_timedelta(win_dur, SAMPLING_RATE)
+        win_dur = audinterface.utils.to_timedelta(win_dur, SAMPLING_RATE)
         if hop_dur is None:
             hop_dur = win_dur / 2
-        hop_dur = audinterface.core.utils.to_timedelta(hop_dur, SAMPLING_RATE)
+        hop_dur = audinterface.utils.to_timedelta(hop_dur, SAMPLING_RATE)
 
         starts = pd.timedelta_range(
             pd.to_timedelta(0),


### PR DESCRIPTION
Closes #59 

~~I also adjusted the return type from `typing.Sequence[pd.Timedelta]` to `pd.TimedeltaIndex`.
I'm also fine with changing the output of the function to the return type we mentioned before, but I'm not sure if this will break the behavior inside `audinterface`.~~

![image](https://user-images.githubusercontent.com/173624/177986328-b76cfbde-28c5-418c-8e43-e5021ab0dc1d.png)

---

I updated related docstrings to link now to this new utility function:

![image](https://user-images.githubusercontent.com/173624/177986389-88932acf-c6f1-4d02-8102-92ef5c2da0f8.png)
