### PR TITLE
DOC: better HTML representations of tables

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,7 +3,6 @@
     :hide-code:
     :hide-output:
 
-    import os
     import pandas as pd
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -3,23 +3,41 @@
     :hide-code:
     :hide-output:
 
+    import os
     import pandas as pd
 
 
-    def series_to_html(self):
-        df = self.to_frame()
+    def dataframe_to_html(df):
+        if len(df.index) > 0:
+            old_path = r'.+/audb'
+            new_path = r'.../audb'
+            # Assuming segmented index
+            df.index = df.index.set_levels(
+                df.index.levels[0].str.replace(
+                    old_path,
+                    new_path,
+                    regex=True,
+                ),
+                level=0,
+            )
+            
+        return df.to_html(max_rows=6, max_cols=3)
+
+            
+    def series_to_html(y):
+        df = y.to_frame()
         df.columns = ['']
-        return df._repr_html_()
+        return dataframe_to_html(df)
 
 
-    def index_to_html(self):
-        return self.to_frame(index=False).to_html(index=False)
+    def index_to_html(index):
+        df = pd.DataFrame(index=index)
+        return dataframe_to_html(df)
 
 
     setattr(pd.Series, '_repr_html_', series_to_html)
     setattr(pd.Index, '_repr_html_', index_to_html)
-    pd.set_option('display.max_rows', 6)
-    pd.set_option('display.max_columns', 3)
+    setattr(pd.DataFrame, '_repr_html_', dataframe_to_html)
 
 .. Specify version for storing and loading objects to YAML
 .. jupyter-execute::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -7,6 +7,7 @@
 
 
     def dataframe_to_html(df):
+        # Replace beginning of data path with ...
         if len(df.index) > 0:
             old_path = r'.+/audb'
             new_path = r'.../audb'


### PR DESCRIPTION
This ensures that the HTML output of `df`, `y`, `index` in the usage section are independent of the root path of the underlying data.
In addition, the index presentation is fixed to look the same as for dataframe or series.

Example:

![image](https://user-images.githubusercontent.com/173624/178499200-5d2e7435-8f92-4ccf-bb5f-d57ad207fea8.png)
