### PR TITLE
TST: test for audobject

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ classifiers =
 packages = find:
 install_requires =
     audformat >=0.15.3,<2.0.0
-    audobject >=0.7.2
     audresample >=1.1.0,<2.0.0
 python_requires = >=3.8
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
 packages = find:
 install_requires =
     audformat >=0.15.3,<2.0.0
+    audobject >=0.7.2
     audresample >=1.1.0,<2.0.0
 python_requires = >=3.8
 setup_requires =

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+audobject >=0.7.5
 # To avoid https://github.com/tholo/pytest-flake8/issues/87
 flake8 <5.0.0
 pytest

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -8,6 +8,7 @@ import pytest
 
 import audinterface
 import audformat
+import audobject
 
 
 def signal_duration(signal, sampling_rate):
@@ -16,6 +17,12 @@ def signal_duration(signal, sampling_rate):
 
 def signal_max(signal, sampling_rate):
     return np.max(signal)
+
+
+class SignalObject(audobject.Object):
+
+    def __call__(self, signal, sampling_rate):
+        return np.max(signal)
 
 
 SEGMENT = audinterface.Segment(
@@ -968,6 +975,12 @@ def test_process_signal(
         ),
         (
             signal_max,
+            np.random.random(5 * 44100),
+            44100,
+            audinterface.utils.signal_index(),
+        ),
+        (
+            SignalObject(),
             np.random.random(5 * 44100),
             44100,
             audinterface.utils.signal_index(),


### PR DESCRIPTION
Closes #68 

This closes the issue by adding a test for `audobject` to identify possible issues earlier.

The actual issue was resolved in `audobject`: in https://github.com/audeering/audobject/pull/49