### PR TITLE
DOC: fix return values of utils.read_audio()

### DIFF
--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -124,8 +124,8 @@ def read_audio(
         root: root folder
 
     Returns:
-        signal: array with signal values in shape ``(channels, samples)``
-        sampling_rate: sampling rate in Hz
+        * array with signal values in shape ``(channels, samples)``
+        * sampling rate in Hz
 
     Example:
         >>> import audb


### PR DESCRIPTION
Changes

![image](https://user-images.githubusercontent.com/173624/194272548-da8ace61-1bb9-42c2-9bbb-fe87d14aeee6.png)

to

![image](https://user-images.githubusercontent.com/173624/194272692-27a3e4a3-851b-4e13-a89c-8ab2028941d1.png)

It seems using `signal: ` before had the consequence that this was used as return type and even affected the order in which "Return type" and "Returns" are presented. 
The order shown for the changes here is in line with the other docstrings.