### PR TITLE
Require audformat>=0.15.3 and flake8<5.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ 3.7, 3.8, 3.9 ]
+        python-version: [ 3.8, 3.9 ]
 
     steps:
     - uses: actions/checkout@v2

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -532,16 +532,7 @@ class Segment:
             progress_bar=self.process.verbose,
             task_description=f'Process {len(index)} segments',
         )
-
-        if len(index.levels) == 2:
-            # Index without 'file' level
-            index = y[0]
-            for obj in y[1:]:
-                index = index.union(obj)
-        else:
-            # For segmented index use audformat.utils.union()
-            # to ensure the correct dtypes are preserved
-            index = audformat.utils.union(y)
+        index = audformat.utils.union(y)
 
         return index
 

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -284,18 +284,10 @@ class Segment:
             end=end,
             root=root,
         ).values[0]
-        return pd.MultiIndex(
-            levels=[
-                [file],
-                index.levels[0] + start,
-                index.levels[1] + start,
-            ],
-            codes=[
-                [0] * len(index),
-                index.codes[0],
-                index.codes[1],
-            ],
-            names=['file', 'start', 'end'],
+        return audformat.segmented_index(
+            files=[file] * len(index),
+            starts=index.levels[0] + start,
+            ends=index.levels[1] + start,
         )
 
     def process_files(
@@ -338,21 +330,15 @@ class Segment:
             ends=ends,
             root=root,
         )
+        if len(series) == 0:
+            return audformat.filewise_index()
         objs = []
         for idx, ((file, start, _), index) in enumerate(series.items()):
             objs.append(
-                pd.MultiIndex(
-                    levels=[
-                        [file],
-                        index.levels[0] + start,
-                        index.levels[1] + start,
-                    ],
-                    codes=[
-                        [0] * len(index),
-                        index.codes[0],
-                        index.codes[1],
-                    ],
-                    names=['file', 'start', 'end'],
+                audformat.segmented_index(
+                    files=[file] * len(index),
+                    starts=index.levels[0] + start,
+                    ends=index.levels[1] + start,
                 )
             )
         return audformat.utils.union(objs)
@@ -482,18 +468,10 @@ class Segment:
                 level=[0, 1],
             )
         if file is not None:
-            index = pd.MultiIndex(
-                levels=[
-                    [file],
-                    index.levels[0],
-                    index.levels[1],
-                ],
-                codes=[
-                    [0] * len(index),
-                    index.codes[0],
-                    index.codes[1],
-                ],
-                names=['file', 'start', 'end'],
+            index = audformat.segmented_index(
+                files=[file] * len(index),
+                starts=index.levels[0],
+                ends=index.levels[1],
             )
         return index
 
@@ -555,9 +533,15 @@ class Segment:
             task_description=f'Process {len(index)} segments',
         )
 
-        index = y[0]
-        for obj in y[1:]:
-            index = index.union(obj)
+        if len(index.levels) == 2:
+            # Index without 'file' level
+            index = y[0]
+            for obj in y[1:]:
+                index = index.union(obj)
+        else:
+            # For segmented index use audformat.utils.union()
+            # to ensure the correct dtypes are preserved
+            index = audformat.utils.union(y)
 
         return index
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
@@ -29,6 +28,7 @@ packages = find:
 install_requires =
     audformat >=0.15.3,<2.0.0
     audresample >=1.1.0,<2.0.0
+python_requires = >=3.8
 setup_requires =
     setuptools_scm
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audformat >=0.12.1,<2.0.0
+    audformat >=0.15.3,<2.0.0
     audresample >=1.1.0,<2.0.0
 setup_requires =
     setuptools_scm

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
+# To avoid https://github.com/tholo/pytest-flake8/issues/87
+flake8 <5.0.0
 pytest
 pytest-flake8
 pytest-doctestplus


### PR DESCRIPTION
This pull requests solves two issues to get the tests working again:

### 1. segmented indices and new `string` dtype

It makes sure to use `audformat.segmented_index()` instead of `pd.MultiIndex` and `audformat.utils.union()` instead of `index.union()` whenever dealing with segemented indices to make sure we get the correct dtype of the `file` level. It uses now only `audformat` functions to make sure it will still work even if we change the behavior of `audformat.sefgmented_index()` again.

### 2. remove support for Python 3.7

As `audformat>=0.15` does only work with Python 3.8, I removed support for Python 3.7 as well.

### 3. flake8 bug

Seems like they don't want to solve https://github.com/tholo/pytest-flake8/issues/87, but propose instead of doing syntax/style checks as `pre-commit`. If I understand this correctly it would run `flake8` locally before doing the commit.
The disadvantage would be that we wouldn't know if everyone uses the same flake8 version.

So for now, let's also restrict the requirements.