### PR TITLE
DOC: disable auto-listing of API entries

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,6 +57,9 @@ autosectionlabel_maxdepth = 2
 copybutton_prompt_text = r'>>> |\.\.\. |$ '
 copybutton_prompt_is_regexp = True
 
+# Disable auto-generation of TOC entries in the API
+# https://github.com/sphinx-doc/sphinx/issues/6316
+toc_object_entries = False
 
 # HTML --------------------------------------------------------------------
 html_theme = 'sphinx_audeering_theme'


### PR DESCRIPTION
First workaround for #79 

This disables the automatic generated entries to restore the original API TOC:

![image](https://user-images.githubusercontent.com/173624/197139675-a5f0fa12-5957-4dc3-98ca-746d81b75dd5.png)
