### PR TITLE
DOC: fix typo in multi-channel usage example

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -209,7 +209,7 @@ on the following multi-channel signal.
 .. jupyter-execute::
 
     df = interface.process_signal(
-        signal,
+        signal_multi_channel,
         sampling_rate,
     )
     df


### PR DESCRIPTION
Before we were passing the mono signal to the first example showing that the first channel is used.

Fixed now:

![image](https://user-images.githubusercontent.com/173624/197523150-3e1a2826-7ab6-4687-b0fc-b0bd991ab09a.png)
