### PR TITLE
Release 0.10.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,15 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 0.10.1 (2023/01/19)
+---------------------------
+
+* Changed: split API documentation into sub-pages
+  for each function
+* Fixed: typo in multi-channel usage example
+  in the documentation
+
+
 Version 0.10.0 (2022-10-24)
 ---------------------------
 


### PR DESCRIPTION
As we now have a new release of `audformat` with the new API doc URLs we can create a new `audinterface` release as well as this might create links to the `audformat` API documentation.

![image](https://user-images.githubusercontent.com/173624/213455981-74d046e6-a7fe-4584-8b29-8f602db9f7bd.png)
