### PR TITLE
Add preserve_index argument to process_index()

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -560,7 +560,6 @@ class Feature:
 
         """
         cache_path = None
-        index_type = audformat.index_type(index)
 
         if cache_root is not None:
             cache_root = audeer.mkdir(cache_root)
@@ -582,11 +581,7 @@ class Feature:
         if self.process.segment is None and preserve_index:
             # Convert segmented index to filewise index
             # if original index was filewise
-            if index_type == audformat.define.IndexType.FILEWISE:
-                files = df.index.get_level_values(
-                    audformat.define.IndexField.FILE
-                )
-                df.index = audformat.filewise_index(files)
+            df.index = index
 
         return df
 

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -116,6 +116,10 @@ class Process:
         file             start   end
         wav/03a01Fa.wav  0 days  0 days 00:00:01.898250    -0.000311
         dtype: float32
+        >>> interface.process_index(index, root=db.root, preserve_index=True)
+        file
+        wav/03a01Fa.wav  -0.000311
+        dtype: float32
         >>> # Apply interface with a sliding window
         >>> interface = Process(
         ...     process_func=mean,
@@ -481,6 +485,7 @@ class Process:
             self,
             index: pd.Index,
             *,
+            preserve_index: bool = False,
             root: str = None,
             cache_root: str = None,
     ) -> pd.Series:
@@ -496,6 +501,12 @@ class Process:
 
         Args:
             index: index with segment information
+            preserve_index: if ``True``
+                and :attr:`audinterface.Process.segment` is ``None``
+                the returned index
+                will be of same type
+                as the original one,
+                otherwise always a segmented index is returned
             root: root folder to expand relative file paths
             cache_root: cache folder (see description)
 
@@ -510,6 +521,7 @@ class Process:
 
         """
         cache_path = None
+        index_type = audformat.index_type(index)
 
         if cache_root is not None:
             cache_root = audeer.mkdir(cache_root)
@@ -528,6 +540,15 @@ class Process:
 
             if cache_path is not None:
                 y.to_pickle(cache_path, protocol=4)
+
+        if self.segment is None and preserve_index:
+            # Convert segmented index to filewise index
+            # if original index was filewise
+            if index_type == audformat.define.IndexType.FILEWISE:
+                files = y.index.get_level_values(
+                    audformat.define.IndexField.FILE
+                )
+                y.index = audformat.filewise_index(files)
 
         return y
 

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -521,7 +521,6 @@ class Process:
 
         """
         cache_path = None
-        index_type = audformat.index_type(index)
 
         if cache_root is not None:
             cache_root = audeer.mkdir(cache_root)
@@ -531,12 +530,15 @@ class Process:
         if cache_path and os.path.exists(cache_path):
             y = pd.read_pickle(cache_path)
         else:
-            index = audformat.utils.to_segmented_index(index)
+            segmented_index = audformat.utils.to_segmented_index(index)
 
             if self.segment is not None:
-                index = self.segment.process_index(index, root=root)
+                segmented_index = self.segment.process_index(
+                    segmented_index,
+                    root=root,
+                )
 
-            y = self._process_index_wo_segment(index, root)
+            y = self._process_index_wo_segment(segmented_index, root)
 
             if cache_path is not None:
                 y.to_pickle(cache_path, protocol=4)
@@ -544,11 +546,7 @@ class Process:
         if self.segment is None and preserve_index:
             # Convert segmented index to filewise index
             # if original index was filewise
-            if index_type == audformat.define.IndexType.FILEWISE:
-                files = y.index.get_level_values(
-                    audformat.define.IndexField.FILE
-                )
-                y.index = audformat.filewise_index(files)
+            y.index = index
 
         return y
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -465,18 +465,45 @@ def test_process_index(tmpdir):
         af.write(path, SIGNAL_2D, SAMPLING_RATE)
     df_expected = np.ones((2, NUM_CHANNELS * NUM_FEATURES))
 
-    # absolute paths
+    # absolute paths segmented index
     index = audformat.segmented_index(paths, [0, 1], [2, 3])
     df = feature.process_index(index)
     assert df.index.get_level_values('file')[0] == paths[0]
     np.testing.assert_array_equal(df.values, df_expected)
     pd.testing.assert_index_equal(df.columns, feature.column_names)
-    df = feature.process_index(index)
 
-    # relative paths
+    # absolute paths filewise index
+    index = audformat.filewise_index(paths)
+    df = feature.process_index(index)
+    assert df.index.get_level_values('file')[0] == paths[0]
+    np.testing.assert_array_equal(df.values, df_expected)
+    pd.testing.assert_index_equal(df.columns, feature.column_names)
+
+    # absolute paths filewise index with preserved index
+    index = audformat.filewise_index(paths)
+    df = feature.process_index(index, preserve_index=True)
+    assert df.index[0] == paths[0]
+    np.testing.assert_array_equal(df.values, df_expected)
+    pd.testing.assert_index_equal(df.columns, feature.column_names)
+
+    # relative paths segmented index
     index = audformat.segmented_index(files, [0, 1], [2, 3])
     df = feature.process_index(index, root=root)
     assert df.index.get_level_values('file')[0] == files[0]
+    np.testing.assert_array_equal(df.values, df_expected)
+    pd.testing.assert_index_equal(df.columns, feature.column_names)
+
+    # relative paths filewise index
+    index = audformat.filewise_index(files)
+    df = feature.process_index(index, root=root)
+    assert df.index.get_level_values('file')[0] == files[0]
+    np.testing.assert_array_equal(df.values, df_expected)
+    pd.testing.assert_index_equal(df.columns, feature.column_names)
+
+    # relative paths filewise index with preserved index
+    index = audformat.filewise_index(files)
+    df = feature.process_index(index, root=root, preserve_index=True)
+    assert df.index[0] == files[0]
     np.testing.assert_array_equal(df.values, df_expected)
     pd.testing.assert_index_equal(df.columns, feature.column_names)
 

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -438,7 +438,8 @@ def test_process_func_args():
         )
 
 
-def test_process_index(tmpdir):
+@pytest.mark.parametrize('preserve_index', [False, True])
+def test_process_index(tmpdir, preserve_index):
 
     cache_root = os.path.join(tmpdir, 'cache')
 
@@ -451,7 +452,7 @@ def test_process_index(tmpdir):
     # empty
 
     index = audformat.segmented_index()
-    df = feature.process_index(index)
+    df = feature.process_index(index, preserve_index=preserve_index)
     assert df.empty
     pd.testing.assert_index_equal(df.columns, feature.column_names)
 
@@ -466,50 +467,43 @@ def test_process_index(tmpdir):
     df_expected = np.ones((2, NUM_CHANNELS * NUM_FEATURES))
 
     # absolute paths segmented index
-    index = audformat.segmented_index(paths, [0, 1], [2, 3])
-    df = feature.process_index(index)
+    index = audformat.segmented_index(paths, [0, 1], [None, 3])
+    df = feature.process_index(index, preserve_index=preserve_index)
     assert df.index.get_level_values('file')[0] == paths[0]
+    np.testing.assert_array_equal(df.values, df_expected)
+    pd.testing.assert_index_equal(df.columns, feature.column_names)
+
+    # relative paths segmented index
+    index = audformat.segmented_index(files, [0, 1], [None, 3])
+    df = feature.process_index(index, preserve_index=preserve_index, root=root)
+    assert df.index.get_level_values('file')[0] == files[0]
     np.testing.assert_array_equal(df.values, df_expected)
     pd.testing.assert_index_equal(df.columns, feature.column_names)
 
     # absolute paths filewise index
     index = audformat.filewise_index(paths)
-    df = feature.process_index(index)
-    assert df.index.get_level_values('file')[0] == paths[0]
-    np.testing.assert_array_equal(df.values, df_expected)
-    pd.testing.assert_index_equal(df.columns, feature.column_names)
-
-    # absolute paths filewise index with preserved index
-    index = audformat.filewise_index(paths)
-    df = feature.process_index(index, preserve_index=True)
-    assert df.index[0] == paths[0]
-    np.testing.assert_array_equal(df.values, df_expected)
-    pd.testing.assert_index_equal(df.columns, feature.column_names)
-
-    # relative paths segmented index
-    index = audformat.segmented_index(files, [0, 1], [2, 3])
-    df = feature.process_index(index, root=root)
-    assert df.index.get_level_values('file')[0] == files[0]
+    df = feature.process_index(index, preserve_index=preserve_index)
+    if preserve_index:
+        assert df.index[0] == paths[0]
+    else:
+        assert df.index.get_level_values('file')[0] == paths[0]
     np.testing.assert_array_equal(df.values, df_expected)
     pd.testing.assert_index_equal(df.columns, feature.column_names)
 
     # relative paths filewise index
     index = audformat.filewise_index(files)
-    df = feature.process_index(index, root=root)
-    assert df.index.get_level_values('file')[0] == files[0]
-    np.testing.assert_array_equal(df.values, df_expected)
-    pd.testing.assert_index_equal(df.columns, feature.column_names)
-
-    # relative paths filewise index with preserved index
-    index = audformat.filewise_index(files)
-    df = feature.process_index(index, root=root, preserve_index=True)
-    assert df.index[0] == files[0]
+    df = feature.process_index(index, preserve_index=preserve_index, root=root)
+    if preserve_index:
+        assert df.index[0] == files[0]
+    else:
+        assert df.index.get_level_values('file')[0] == files[0]
     np.testing.assert_array_equal(df.values, df_expected)
     pd.testing.assert_index_equal(df.columns, feature.column_names)
 
     # cache result
     df = feature.process_index(
         index,
+        preserve_index=preserve_index,
         root=root,
         cache_root=cache_root,
     )
@@ -519,12 +513,14 @@ def test_process_index(tmpdir):
     with pytest.raises(RuntimeError):
         feature.process_index(
             index,
+            preserve_index=preserve_index,
             root=root,
         )
 
     # loading from cache still works
     df_cached = feature.process_index(
         index,
+        preserve_index=preserve_index,
         root=root,
         cache_root=cache_root,
     )

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -470,6 +470,8 @@ def test_process_index(tmpdir, preserve_index):
     index = audformat.segmented_index(paths, [0, 1], [None, 3])
     df = feature.process_index(index, preserve_index=preserve_index)
     assert df.index.get_level_values('file')[0] == paths[0]
+    if preserve_index:
+        pd.testing.assert_index_equal(df.index, index)
     np.testing.assert_array_equal(df.values, df_expected)
     pd.testing.assert_index_equal(df.columns, feature.column_names)
 
@@ -477,6 +479,8 @@ def test_process_index(tmpdir, preserve_index):
     index = audformat.segmented_index(files, [0, 1], [None, 3])
     df = feature.process_index(index, preserve_index=preserve_index, root=root)
     assert df.index.get_level_values('file')[0] == files[0]
+    if preserve_index:
+        pd.testing.assert_index_equal(df.index, index)
     np.testing.assert_array_equal(df.values, df_expected)
     pd.testing.assert_index_equal(df.columns, feature.column_names)
 
@@ -485,6 +489,7 @@ def test_process_index(tmpdir, preserve_index):
     df = feature.process_index(index, preserve_index=preserve_index)
     if preserve_index:
         assert df.index[0] == paths[0]
+        pd.testing.assert_index_equal(df.index, index)
     else:
         assert df.index.get_level_values('file')[0] == paths[0]
     np.testing.assert_array_equal(df.values, df_expected)
@@ -495,6 +500,7 @@ def test_process_index(tmpdir, preserve_index):
     df = feature.process_index(index, preserve_index=preserve_index, root=root)
     if preserve_index:
         assert df.index[0] == files[0]
+        pd.testing.assert_index_equal(df.index, index)
     else:
         assert df.index.get_level_values('file')[0] == files[0]
     np.testing.assert_array_equal(df.values, df_expected)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -591,6 +591,8 @@ def test_process_index(tmpdir, num_workers, multiprocessing, preserve_index):
         index,
         preserve_index=preserve_index,
     )
+    if preserve_index:
+        pd.testing.assert_index_equal(y.index, index)
     for (path, start, end), value in y.items():
         signal, sampling_rate = audinterface.utils.read_audio(
             path, start=start, end=end
@@ -608,6 +610,8 @@ def test_process_index(tmpdir, num_workers, multiprocessing, preserve_index):
         preserve_index=preserve_index,
         root=root,
     )
+    if preserve_index:
+        pd.testing.assert_index_equal(y.index, index)
     for (file, start, end), value in y.items():
         signal, sampling_rate = audinterface.utils.read_audio(
             file, start=start, end=end, root=root
@@ -621,6 +625,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing, preserve_index):
         preserve_index=preserve_index,
     )
     if preserve_index:
+        pd.testing.assert_index_equal(y.index, index)
         for path, value in y.items():
             signal, sampling_rate = audinterface.utils.read_audio(path)
             np.testing.assert_equal(signal, value)
@@ -639,6 +644,7 @@ def test_process_index(tmpdir, num_workers, multiprocessing, preserve_index):
         root=root,
     )
     if preserve_index:
+        pd.testing.assert_index_equal(y.index, index)
         for file, value in y.items():
             signal, sampling_rate = audinterface.utils.read_audio(
                 file, root=root,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -651,7 +651,6 @@ def test_process_index(tmpdir, num_workers, multiprocessing, preserve_index):
             )
             np.testing.assert_equal(signal, value)
 
-
     # cache result
     y = process.process_index(
         index,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -602,6 +602,13 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
         )
         np.testing.assert_equal(signal, value)
 
+    # filewise index with absolute paths and preserved index
+    index = audformat.filewise_index(path)
+    y = process.process_index(index, preserve_index=True)
+    for path, value in y.items():
+        signal, sampling_rate = audinterface.utils.read_audio(path)
+        np.testing.assert_equal(signal, value)
+
     # segmented index with relative paths
     index = audformat.segmented_index(
         [file] * 3,
@@ -621,6 +628,15 @@ def test_process_index(tmpdir, num_workers, multiprocessing):
     for (file, start, end), value in y.items():
         signal, sampling_rate = audinterface.utils.read_audio(
             file, start=start, end=end, root=root
+        )
+        np.testing.assert_equal(signal, value)
+
+    # filewise index with relative paths and preserved index
+    index = audformat.filewise_index(path)
+    y = process.process_index(index, preserve_index=True, root=root)
+    for file, value in y.items():
+        signal, sampling_rate = audinterface.utils.read_audio(
+            file, root=root
         )
         np.testing.assert_equal(signal, value)
 


### PR DESCRIPTION
Closes #71 

This adds the argument `preserve_index` to `Process.process_index()` and `Feature.process_index()`. If `True` it will return a filewise index instead of a segmented index if provided with a filewise index. This has the advantage that one can directly assign the result to a dataframe with the original index as outlined in #71.

It's not implemented in the most elegant way as nearly all internal private functions and the caching requires segmented index. If `preserve_index=True` the index is first converted to a segmented index anyway and also the results are always cached as a segmented index. We just convert the index back to a segmented index before returning it to the user.

### Docstring and example for Process

![image](https://user-images.githubusercontent.com/173624/216251496-d2a66ee6-9f46-45d2-84f7-a1b2bd6c8f88.png)

![image](https://user-images.githubusercontent.com/173624/216251607-0cb12703-711a-46a4-981a-578401409767.png)

### Docstring and example for Feature

![image](https://user-images.githubusercontent.com/173624/216251718-ccbe4c15-d29f-45d3-86ee-43e3f8ad6505.png)

![image](https://user-images.githubusercontent.com/173624/216251793-59da4d2f-f4f3-42f8-b60c-09708ff181b6.png)


