### PR TITLE
Use audmath in audinterface.utils.to_timedelta()

### DIFF
--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -256,8 +256,10 @@ class Process:
             end: pd.Timedelta = None,
     ) -> pd.Series:
 
-        start = utils.to_timedelta(start, self.sampling_rate)
-        end = utils.to_timedelta(end, self.sampling_rate)
+        if start is not None:
+            start = utils.to_timedelta(start, self.sampling_rate)
+        if end is not None:
+            end = utils.to_timedelta(end, self.sampling_rate)
 
         signal, sampling_rate = utils.read_audio(
             file,
@@ -687,8 +689,10 @@ class Process:
                 index,
             )
         else:
-            start = utils.to_timedelta(start, sampling_rate)
-            end = utils.to_timedelta(end, sampling_rate)
+            if start is not None:
+                start = utils.to_timedelta(start, sampling_rate)
+            if end is not None:
+                end = utils.to_timedelta(end, sampling_rate)
             return self._process_signal(
                 signal,
                 sampling_rate,

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -407,7 +407,7 @@ def to_timedelta(
     The single duration values
     support all formats
     mentioned in :func:`audmath.duration_in_seconds`,
-    like ``'2 ms'``, or ``pd.to_timedelta(2, 's')``.
+    like ``'2 ms'``, or ``pandas.to_timedelta(2, 's')``.
     The exception is
     that float and integer values
     are always interpreted as seconds

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -404,20 +404,15 @@ def to_timedelta(
 ) -> typing.Union[pd.Timedelta, typing.List[pd.Timedelta]]:
     r"""Convert duration value(s) to :class:`pandas.Timedelta`.
 
-    If duration is given as string without unit,
-    it is treated as samples
-    and requires that ``'sampling_rate'`` is not ``None``.
-
-    .. warning::
-
-        From version 1.0.0 not providing ``sampling_rate``
-        no longer raises an error
-        when duration is provided
-        as a string value without unit,
-        but the string value will be interpreted as seconds;
-        if ``sampling_rate`` is provided
-        integer and float duration values
-        will be interpreted as seconds.
+    The single duration values
+    support all formats
+    mentioned in :func:`audmath.duration_in_seconds`,
+    like ``'2 ms'``, or ``pd.to_timedelta(2, 's')``.
+    The exception is
+    that float and integer values
+    are always interpreted as seconds
+    and strings without unit
+    always as samples.
 
     Args:
         durations: duration value(s).
@@ -452,12 +447,7 @@ def to_timedelta(
 
     """  # noqa: E501
     def duration_in_seconds(duration, sampling_rate):
-        """Helper function to convert to seconds.
-
-        We will remove this helper function in version 1.0.0 of audinterface
-        and replace it by calling directly audmath.duration_in_seconds().
-
-        """
+        """Helper function to convert to seconds."""
         if not isinstance(duration, str):
             # force non-string values to represent seconds
             sampling_rate = None
@@ -468,9 +458,6 @@ def to_timedelta(
                     "You have to provide 'sampling_rate' "
                     "when specifying the duration in samples "
                     f"as you did with '{duration}'. "
-                    "NOTE: this will no longer raise an error "
-                    "in version 1.0.0, "
-                    f"but interpret '{duration}' in seconds."
                 )
         return audmath.duration_in_seconds(duration, sampling_rate)
 

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -432,7 +432,7 @@ def to_timedelta(
     Raises:
         ValueError: if a duration value is given in samples,
             but ``sampling_rate`` is ``None``
-        ValueError: if ``duration`` is a string
+        ValueError: if a duration is a string
             that does not match a valid '<value><unit>' pattern
             or the provided unit is not supported
 

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -408,6 +408,17 @@ def to_timedelta(
     it is treated as samples
     and requires that ``'sampling_rate'`` is not ``None``.
 
+    .. warning::
+
+        From version 1.0.0 not providing ``sampling_rate``
+        no longer raises an error
+        when duration is provided
+        as a string value without unit,
+        but the string value will be interpreted as seconds;
+        if ``sampling_rate`` is provided
+        integer and float duration values
+        will be interpreted as seconds.
+
     Args:
         durations: duration value(s).
             If value is a float or integer

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -441,9 +441,17 @@ def to_timedelta(
 
     """  # noqa: E501
     def duration_in_seconds(duration, sampling_rate):
-        # Force non-string values to represent seconds
         if not isinstance(duration, str):
+            # force non-string values to represent seconds
             sampling_rate = None
+        elif all(d.isdigit() for d in duration):
+            # force string without unit to represent samples
+            if sampling_rate is None:
+                raise ValueError(
+                    "You have to provide 'sampling_rate' "
+                    "when specifying the duration in samples "
+                    f"as you did with '{duration}'."
+                )
         # Don't try to convert NaT/None values
         if not pd.isnull(duration):
             duration = audmath.duration_in_seconds(duration, sampling_rate)
@@ -451,9 +459,8 @@ def to_timedelta(
 
     if (
             not isinstance(durations, str)
-            or not isinstance(durations, collections.abc.Iterable)
+            and isinstance(durations, collections.abc.Iterable)
     ):
-        print(f'{durations=}')
         # sequence of duration entries
         durations = [
             duration_in_seconds(duration, sampling_rate)

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -432,6 +432,9 @@ def to_timedelta(
     Raises:
         ValueError: if a duration value is given in samples,
             but ``sampling_rate`` is ``None``
+        ValueError: if ``duration`` is a string
+            that does not match a valid '<value><unit>' pattern
+            or the provided unit is not supported
 
     Examples:
         >>> to_timedelta(2)

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -452,6 +452,12 @@ def to_timedelta(
 
     """  # noqa: E501
     def duration_in_seconds(duration, sampling_rate):
+        """Helper function to convert to seconds.
+
+        We will remove this helper function in version 1.0.0 of audinterface
+        and replace it by calling directly audmath.duration_in_seconds().
+
+        """
         if not isinstance(duration, str):
             # force non-string values to represent seconds
             sampling_rate = None
@@ -466,8 +472,7 @@ def to_timedelta(
                     "in version 1.0.0, "
                     f"but interpret '{duration}' in seconds."
                 )
-        duration = audmath.duration_in_seconds(duration, sampling_rate)
-        return duration
+        return audmath.duration_in_seconds(duration, sampling_rate)
 
     if (
             not isinstance(durations, str)

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -450,9 +450,12 @@ def to_timedelta(
                 raise ValueError(
                     "You have to provide 'sampling_rate' "
                     "when specifying the duration in samples "
-                    f"as you did with '{duration}'."
+                    f"as you did with '{duration}'. "
+                    "NOTE: this will no longer raise an error "
+                    "in version 1.0.0, "
+                    f"but interpret '{duration}' in seconds."
                 )
-        # Don't try to convert NaT/None values
+        # Don't try to convert NaT values
         if not pd.isnull(duration):
             duration = audmath.duration_in_seconds(duration, sampling_rate)
         return duration

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -1,6 +1,7 @@
 import collections
 import os
 import typing
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -458,21 +459,29 @@ def to_timedelta(
         and replace it by calling directly audmath.duration_in_seconds().
 
         """
-        if not isinstance(duration, str):
+        if (
+                sampling_rate is not None
+                and isinstance(duration, (np.floating, float))
+        ):
             # force non-string values to represent seconds
             sampling_rate = None
-        elif all(d.isdigit() for d in duration):
-            # force string without unit to represent samples
-            if sampling_rate is None:
-                raise ValueError(
-                    "You have to provide 'sampling_rate' "
-                    "when specifying the duration in samples "
-                    f"as you did with '{duration}'. "
-                    "NOTE: this will no longer raise an error "
-                    "in version 1.0.0, "
-                    f"but interpret '{duration}' in seconds."
-                )
         return audmath.duration_in_seconds(duration, sampling_rate)
+
+    if sampling_rate is not None:
+        is_numeric = any(
+            [
+                isinstance(duration, (np.floating, float))
+                for duration in audeer.to_list(durations)
+            ]
+        )
+        if is_numeric:
+            message = (
+                "Providing duration as float or integer "
+                "will be interpreted as samples "
+                "from version 1.0.0 "
+                "when 'sampling_rate' is provided as well."
+            )
+            warnings.warn(message, category=UserWarning, stacklevel=2)
 
     if (
             not isinstance(durations, str)

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -455,9 +455,7 @@ def to_timedelta(
                     "in version 1.0.0, "
                     f"but interpret '{duration}' in seconds."
                 )
-        # Don't try to convert NaT values
-        if not pd.isnull(duration):
-            duration = audmath.duration_in_seconds(duration, sampling_rate)
+        duration = audmath.duration_in_seconds(duration, sampling_rate)
         return duration
 
     if (

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -1,7 +1,6 @@
 import collections
 import os
 import typing
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -459,29 +458,21 @@ def to_timedelta(
         and replace it by calling directly audmath.duration_in_seconds().
 
         """
-        if (
-                sampling_rate is not None
-                and isinstance(duration, (np.floating, float))
-        ):
+        if not isinstance(duration, str):
             # force non-string values to represent seconds
             sampling_rate = None
+        elif all(d.isdigit() for d in duration):
+            # force string without unit to represent samples
+            if sampling_rate is None:
+                raise ValueError(
+                    "You have to provide 'sampling_rate' "
+                    "when specifying the duration in samples "
+                    f"as you did with '{duration}'. "
+                    "NOTE: this will no longer raise an error "
+                    "in version 1.0.0, "
+                    f"but interpret '{duration}' in seconds."
+                )
         return audmath.duration_in_seconds(duration, sampling_rate)
-
-    if sampling_rate is not None:
-        is_numeric = any(
-            [
-                isinstance(duration, (np.floating, float))
-                for duration in audeer.to_list(durations)
-            ]
-        )
-        if is_numeric:
-            message = (
-                "Providing duration as float or integer "
-                "will be interpreted as samples "
-                "from version 1.0.0 "
-                "when 'sampling_rate' is provided as well."
-            )
-            warnings.warn(message, category=UserWarning, stacklevel=2)
 
     if (
             not isinstance(durations, str)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,13 +45,14 @@ extensions = [
     'sphinx_copybutton',  # for "copy to clipboard" buttons
 ]
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'audformat': ('https://audeering.github.io/audformat/', None),
+    'audmath': ('https://audeering.github.io/audmath/', None),
     'audobject': ('https://audeering.github.io/audobject/', None),
     'audresample': ('https://audeering.github.io/audresample/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
     'opensmile': ('https://audeering.github.io/opensmile-python/', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'python': ('https://docs.python.org/3/', None),
 }
 # Disable Gitlab as we need to sign in
 linkcheck_ignore = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ classifiers =
 packages = find:
 install_requires =
     audformat >=0.15.3,<2.0.0
+    audmath >=1.2.0
     audresample >=1.1.0,<2.0.0
 python_requires = >=3.8
 setup_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 packages = find:
 install_requires =
     audformat >=0.15.3,<2.0.0
-    audmath >=1.2.0
+    audmath >=1.2.1
     audresample >=1.1.0,<2.0.0
 python_requires = >=3.8
 setup_requires =

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -392,6 +392,24 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
             ),
             ValueError,
         ),
+        (
+            '200 a b',
+            None,
+            (
+                "Your given duration '200 a b' "
+                "is not conform to the <value><unit> pattern."
+            ),
+            ValueError,
+        ),
+        (
+            [200, '200 a b'],
+            None,
+            (
+                "Your given duration '200 a b' "
+                "is not conform to the <value><unit> pattern."
+            ),
+            ValueError,
+        ),
     ]
 )
 def test_to_timedelta_errors(durations, sampling_rate, error_msg, error):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+import re
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -365,3 +367,39 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
         hop_dur,
     )
     np.testing.assert_equal(frames, expected)
+
+
+@pytest.mark.parametrize(
+    'durations, sampling_rate, error_msg, error',
+    [
+        (
+            '200',
+            None,
+            (
+                "You have to provide 'sampling_rate' "
+                "when specifying the duration in samples "
+                "as you did with ''200''. "
+                "NOTE: this will no longer raise an error "
+                "in version 1.0.0, "
+                "but interpret ''200'' in seconds."
+            ),
+            ValueError,
+        ),
+        (
+            [200, '200'],
+            None,
+            (
+                "You have to provide 'sampling_rate' "
+                "when specifying the duration in samples "
+                "as you did with ''200''. "
+                "NOTE: this will no longer raise an error "
+                "in version 1.0.0, "
+                "but interpret ''200'' in seconds."
+            ),
+            ValueError,
+        ),
+    ]
+)
+def test_to_timedelta_errors(durations, sampling_rate, error_msg, error):
+    with pytest.raises(error, match=re.escape(error_msg)):
+        audinterface.utils.to_timedelta(durations, sampling_rate)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -370,36 +370,19 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
 
 
 @pytest.mark.parametrize(
-    'durations, sampling_rate, error_msg, error',
+    'durations',
     [
-        (
-            '200',
-            None,
-            (
-                "You have to provide 'sampling_rate' "
-                "when specifying the duration in samples "
-                "as you did with '200'. "
-                "NOTE: this will no longer raise an error "
-                "in version 1.0.0, "
-                "but interpret '200' in seconds."
-            ),
-            ValueError,
-        ),
-        (
-            [200, '200'],
-            None,
-            (
-                "You have to provide 'sampling_rate' "
-                "when specifying the duration in samples "
-                "as you did with '200'. "
-                "NOTE: this will no longer raise an error "
-                "in version 1.0.0, "
-                "but interpret '200' in seconds."
-            ),
-            ValueError,
-        ),
+        1,
+        [2.0, '200'],
     ]
 )
-def test_to_timedelta_errors(durations, sampling_rate, error_msg, error):
-    with pytest.raises(error, match=re.escape(error_msg)):
+def test_to_timedelta_warnings(durations):
+    sampling_rate = 8000
+    message = (
+        "Providing duration as float or integer "
+        "will be interpreted as samples "
+        "from version 1.0.0 "
+        "when 'sampling_rate' is provided as well."
+    )
+    with pytest.warns(UserWarning, match=re.escape(message)):
         audinterface.utils.to_timedelta(durations, sampling_rate)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -379,9 +379,6 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
                 "You have to provide 'sampling_rate' "
                 "when specifying the duration in samples "
                 "as you did with '200'. "
-                "NOTE: this will no longer raise an error "
-                "in version 1.0.0, "
-                "but interpret '200' in seconds."
             ),
             ValueError,
         ),
@@ -392,9 +389,6 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
                 "You have to provide 'sampling_rate' "
                 "when specifying the duration in samples "
                 "as you did with '200'. "
-                "NOTE: this will no longer raise an error "
-                "in version 1.0.0, "
-                "but interpret '200' in seconds."
             ),
             ValueError,
         ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -378,10 +378,10 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
             (
                 "You have to provide 'sampling_rate' "
                 "when specifying the duration in samples "
-                "as you did with ''200''. "
+                "as you did with '200'. "
                 "NOTE: this will no longer raise an error "
                 "in version 1.0.0, "
-                "but interpret ''200'' in seconds."
+                "but interpret '200' in seconds."
             ),
             ValueError,
         ),
@@ -391,10 +391,10 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
             (
                 "You have to provide 'sampling_rate' "
                 "when specifying the duration in samples "
-                "as you did with ''200''. "
+                "as you did with '200'. "
                 "NOTE: this will no longer raise an error "
                 "in version 1.0.0, "
-                "but interpret ''200'' in seconds."
+                "but interpret '200' in seconds."
             ),
             ValueError,
         ),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -370,19 +370,36 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
 
 
 @pytest.mark.parametrize(
-    'durations',
+    'durations, sampling_rate, error_msg, error',
     [
-        1,
-        [2.0, '200'],
+        (
+            '200',
+            None,
+            (
+                "You have to provide 'sampling_rate' "
+                "when specifying the duration in samples "
+                "as you did with '200'. "
+                "NOTE: this will no longer raise an error "
+                "in version 1.0.0, "
+                "but interpret '200' in seconds."
+            ),
+            ValueError,
+        ),
+        (
+            [200, '200'],
+            None,
+            (
+                "You have to provide 'sampling_rate' "
+                "when specifying the duration in samples "
+                "as you did with '200'. "
+                "NOTE: this will no longer raise an error "
+                "in version 1.0.0, "
+                "but interpret '200' in seconds."
+            ),
+            ValueError,
+        ),
     ]
 )
-def test_to_timedelta_warnings(durations):
-    sampling_rate = 8000
-    message = (
-        "Providing duration as float or integer "
-        "will be interpreted as samples "
-        "from version 1.0.0 "
-        "when 'sampling_rate' is provided as well."
-    )
-    with pytest.warns(UserWarning, match=re.escape(message)):
+def test_to_timedelta_errors(durations, sampling_rate, error_msg, error):
+    with pytest.raises(error, match=re.escape(error_msg)):
         audinterface.utils.to_timedelta(durations, sampling_rate)


### PR DESCRIPTION
This updates `audinterface.utils.to_timedelta()` to use `audmath.duration_in_seconds()` as single source of truth for conversion to seconds.

The behavior of `audinterface.utils.to_timedelta()` is not changed as we have only a single `sampling_rate` argument for a whole list of duration values:
* float and integer values will always be tyreated as representing duration in seconds
* only string values without a unit are expected to represent samples, and we raise an error if such a value is given, but no `sampling_rate` value

![image](https://user-images.githubusercontent.com/173624/217468903-e2ecff0b-81bd-4f4f-9c46-4d4270b1d758.png)
