### PR TITLE
CI: cache emodb database

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
+    - name: Cache emodb
+      uses: actions/cache@v3
+      with:
+        path: ~/audb
+        key: emodb-1.3.0
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,7 @@ audinterface
 
 Generic interfaces for signal processing.
 
+
 **audinterface** provides user interfaces
 to apply any machine learning model
 or digital signal processing algorithm

--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,6 @@ audinterface
 
 Generic interfaces for signal processing.
 
-
 **audinterface** provides user interfaces
 to apply any machine learning model
 or digital signal processing algorithm


### PR DESCRIPTION
As we use `emodb` loaded by `audb` in the documentation examples, it will make sense to cache the data as we do in https://github.com/audeering/audb to avoid reloading the data with every pipeline from the external server.