### PR TITLE
Speed up ProcessWithContext.process_*()

### DIFF
--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -242,6 +242,14 @@ def test_process_index(tmpdir):
             ),
             marks=pytest.mark.xfail(raises=RuntimeError),
         ),
+        pytest.param(  # not a valid index
+            lambda signal, sampling_rate: [0, 1],
+            lambda signal, sampling_rate, starts, ends: [0, 1],
+            np.random.random(5 * 44100),
+            44100,
+            pd.Index([]),
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
     ],
 )
 def test_process_signal_from_index(

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -133,6 +133,10 @@ def test_process_index(tmpdir):
         )
         np.testing.assert_equal(np.atleast_2d(x[channel]), value)
 
+    # bad index
+    with pytest.raises(ValueError):
+        process.process_index(pd.Index([]), root=root)
+
 
 @pytest.mark.parametrize(
     'process_func,process_func_with_context,signal,sampling_rate,index',


### PR DESCRIPTION
Relates to #100 

Speeds up `PredictWithContext.process_*()` by avoiding calls to `pd.concat()` on a lot of small `pd.Series` objects. Instead, we now concatenate lists and create the final `pd.Series` from those.

### Benchmark

```python
import time
import audb
import audinterface


db = audb.load(
    'emodb',
    version='1.3.0',
    format='wav',
    sampling_rate=16000,
    mixdown=True,
)

def process_func(x, sr, starts, ends):
    y = []
    for start, end in zip(starts, ends):
        y.append(x[:, start:end].mean())
    return y

process = audinterface.ProcessWithContext(process_func=process_func)

t = time.time()
process.process_index(db.files)
print(time.time() - t)
```

* main branch: ~4.0 s
* this branch: ~0.6 s
