### PR TITLE
Speed up Segment.process_*()

### DIFF
--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -325,19 +325,19 @@ class Segment:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        series = self.process.process_files(
+        y = self.process.process_files(
             files,
             starts=starts,
             ends=ends,
             root=root,
         )
-        if len(series) == 0:
+        if len(y) == 0:
             return audformat.filewise_index()
 
         files = []
         starts = []
         ends = []
-        for idx, ((file, start, _), index) in enumerate(series.items()):
+        for idx, ((file, start, _), index) in enumerate(y.items()):
             files.extend([file] * len(index))
             starts.extend(index.levels[0] + start)
             ends.extend(index.levels[1] + start)

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -333,16 +333,16 @@ class Segment:
         )
         if len(series) == 0:
             return audformat.filewise_index()
-        objs = []
+
+        files = []
+        starts = []
+        ends = []
         for idx, ((file, start, _), index) in enumerate(series.items()):
-            objs.append(
-                audformat.segmented_index(
-                    files=[file] * len(index),
-                    starts=index.levels[0] + start,
-                    ends=index.levels[1] + start,
-                )
-            )
-        return audformat.utils.union(objs)
+            files.extend([file] * len(index))
+            starts.extend(index.levels[0] + start)
+            ends.extend(index.levels[1] + start)
+
+        return audformat.segmented_index(files, starts, ends)
 
     def process_folder(
             self,
@@ -545,10 +545,11 @@ class Segment:
         r"""Apply processing to signal.
 
         This function processes the signal **without** transforming the output
-        into a :class:`pd.MultiIndex`. Instead it will return the raw processed
-        signal. However, if channel selection, mixdown and/or resampling
-        is enabled, the signal will be first remixed and resampled if the
-        input sampling rate does not fit the expected sampling rate.
+        into a :class:`pd.MultiIndex`. Instead, it will return the raw
+        processed signal. However, if channel selection, mixdown
+        and/or resampling is enabled, the signal will be first remixed and
+        resampled if the input sampling rate does not fit the expected
+        sampling rate.
 
         Args:
             signal: signal values


### PR DESCRIPTION
Closes #106 

Avoids calling `audformat.utils.union()` by collecting files, starts and ends in a list and use them to directly create the final index.