### PR TITLE
Fix precision of end times

### DIFF
--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -253,8 +253,14 @@ class Process:
 
         if start is not None:
             start = utils.to_timedelta(start, self.sampling_rate)
+            file_start = start - start
+        else:
+            file_start = None
         if end is not None:
             end = utils.to_timedelta(end, self.sampling_rate)
+            file_end = end - start
+        else:
+            file_end = None
 
         signal, sampling_rate = utils.read_audio(
             file,
@@ -269,6 +275,8 @@ class Process:
             idx=idx,
             root=root,
             file=file,
+            start=file_start,
+            end=file_end,
         )
 
         if self.win_dur is not None:
@@ -585,7 +593,7 @@ class Process:
         if start is None or pd.isna(start):
             start = pd.to_timedelta(0)
         if end is None or (pd.isna(end) and not self.keep_nat):
-            end = pd.to_timedelta(signal.shape[-1] / sampling_rate, unit='s')
+            end = utils.to_timedelta(str(signal.shape[-1]), sampling_rate)
         start_i, end_i = utils.segment_to_indices(
             signal, sampling_rate, start, end,
         )

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -470,11 +470,15 @@ def to_timedelta(
         # single duration entry
         if not isinstance(durations, pd.Timedelta):
             durations = duration_in_seconds(durations, sampling_rate)
+            durations = pd.to_timedelta(durations, unit='s')
             # Limit precision to 6 digits
-            # by converting to milliseconds and rounding
-            # to avoid rounding error in index
+            # to mimick previous behavior of pandas
             # compare https://github.com/audeering/audinterface/issues/113
-            durations = round(float(durations) * 10 ** 3, 3)
-            durations = pd.to_timedelta(durations, unit='ms')
+            precision = 6
+            durations_str = str(durations)
+            num_digits = len(durations_str.split('.')[-1])
+            if num_digits > precision:
+                durations_str = durations_str[:precision - num_digits]
+                durations = pd.Timedelta(durations_str)
 
     return durations

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -476,9 +476,11 @@ def to_timedelta(
             # compare https://github.com/audeering/audinterface/issues/113
             precision = 6
             durations_str = str(durations)
-            num_digits = len(durations_str.split('.')[-1])
-            if num_digits > precision:
-                durations_str = durations_str[:precision - num_digits]
-                durations = pd.Timedelta(durations_str)
+            durations_str_parts = durations_str.split('.')
+            if len(durations_str_parts) > 1:  # check if we have digits at all
+                num_digits = len(durations_str_parts[-1])
+                if num_digits > precision:
+                    durations_str = durations_str[:precision - num_digits]
+                    durations = pd.Timedelta(durations_str)
 
     return durations

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -463,16 +463,18 @@ def to_timedelta(
     ):
         # sequence of duration entries
         durations = [
-            duration_in_seconds(duration, sampling_rate)
+            to_timedelta(duration, sampling_rate)
             for duration in durations
         ]
     else:
         # single duration entry
-        durations = duration_in_seconds(durations, sampling_rate)
-
-    durations = pd.to_timedelta(durations, unit='s')
-
-    if isinstance(durations, pd.TimedeltaIndex):
-        durations = list(durations)
+        if not isinstance(durations, pd.Timedelta):
+            durations = duration_in_seconds(durations, sampling_rate)
+            # Limit precision to 6 digits
+            # by converting to milliseconds and rounding
+            # to avoid rounding error in index
+            # compare https://github.com/audeering/audinterface/issues/113
+            durations = round(float(durations) * 10 ** 3, 3)
+            durations = pd.to_timedelta(durations, unit='ms')
 
     return durations

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -527,28 +527,6 @@ def test_process_index(tmpdir, preserve_index):
     pd.testing.assert_frame_equal(df, df_cached)
 
 
-def test_process_index_time_precision(tmpdir):
-    r"""Test index start, end values are correctly rounded.
-
-    This ensures the issue reported at
-    https://github.com/audeering/audinterface/issues/113
-    is fixed.
-
-    """
-    root = audeer.mkdir(audeer.path(tmpdir, 'audio'))
-    sampling_rate = 8000
-    duration = 0.127375  # => 1019 samples
-    signal = np.ones((1, int(duration * sampling_rate)))
-    audiofile.write(
-        audeer.path(root, 'f.wav'),
-        signal,
-        sampling_rate,
-    )
-    index = audformat.segmented_index(['f.wav'], [0], [duration])
-    ends = index.get_level_values('end')
-    assert ends[0].total_seconds() == duration
-
-
 @pytest.mark.parametrize(
     'process_func, applies_sliding_window, num_feat, signal, start, end, '
     'is_mono, expected',

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -527,6 +527,28 @@ def test_process_index(tmpdir, preserve_index):
     pd.testing.assert_frame_equal(df, df_cached)
 
 
+def test_process_index_time_precision(tmpdir):
+    r"""Test index start, end values are correctly rounded.
+
+    This ensures the issue reported at
+    https://github.com/audeering/audinterface/issues/113
+    is fixed.
+
+    """
+    root = audeer.mkdir(audeer.path(tmpdir, 'audio'))
+    sampling_rate = 8000
+    duration = 0.127375  # => 1019 samples
+    signal = np.ones((1, int(duration * sampling_rate)))
+    audiofile.write(
+        audeer.path(root, 'f.wav'),
+        signal,
+        sampling_rate,
+    )
+    index = audformat.segmented_index(['f.wav'], [0], [duration])
+    ends = index.get_level_values('end')
+    assert ends[0].total_seconds() == duration
+
+
 @pytest.mark.parametrize(
     'process_func, applies_sliding_window, num_feat, signal, start, end, '
     'is_mono, expected',


### PR DESCRIPTION
Closes #113 

This ensures that `process_index(..., preserve_index=False)` does not change existing `end` values that are real times by passing them on to `process_file()` so that the duration is not calculated again from the file duration.

```python
import audb
import os
import audinterface

media = [
    'wav/03a01Fa.wav',
    'wav/03a01Nc.wav',
    'wav/16b10Wb.wav',
    'wav/03a01Wa.wav'
]
db = audb.load(
    'emodb',
    version='1.3.0',
    media=media,
    verbose=False,
)

files = list(db.files)
folder = os.path.dirname(files[0])
df = db['emotion'].get(as_segmented=True, allow_nat=False)
print(df)

def features(signal, sampling_rate):
    return [signal.mean(), signal.std()]

interface = audinterface.Feature(
    ['mean', 'std'],
    process_func=features,
)
df = interface.process_index(df.index)
print(df)
```
returns
```
                                                                                   emotion  emotion.confidence
file                                              start  end                                                  
/home/audeering.local/hwierstorf/audb/emodb/1.... 0 days 0 days 00:00:01.898250  happiness                0.90
                                                         0 days 00:00:01.611250    neutral                1.00
                                                         0 days 00:00:01.877812      anger                0.95
                                                         0 days 00:00:02.522499      anger                1.00
                                                                                     mean       std
file                                              start  end                                       
/home/audeering.local/hwierstorf/audb/emodb/1.... 0 days 0 days 00:00:01.898250 -0.000311  0.082317
                                                         0 days 00:00:01.611250 -0.000312  0.125304
                                                         0 days 00:00:01.877812 -0.000296  0.127394
                                                         0 days 00:00:02.522499 -0.000464  0.095558
```

It also limits the precision when calculating the duration to 6 digits when calculating it for filewise indices.

```python
df = db['emotion'].get()
df = interface.process_index(df.index)
print(df)
```
now returns
```
                                                                                     mean       std
file                                              start  end                                       
/home/audeering.local/hwierstorf/audb/emodb/1.... 0 days 0 days 00:00:01.898250 -0.000311  0.082317
                                                         0 days 00:00:01.611250 -0.000312  0.125304
                                                         0 days 00:00:01.877812 -0.000296  0.127394
                                                         0 days 00:00:02.522500 -0.000464  0.095558
```
instead of
```
                                                                                        mean       std
file                                              start  end                                          
/home/audeering.local/hwierstorf/audb/emodb/1.... 0 days 0 days 00:00:01.898250    -0.000311  0.082317
                                                         0 days 00:00:01.611250    -0.000312  0.125304
                                                         0 days 00:00:01.877812500 -0.000296  0.127394
                                                         0 days 00:00:02.522499999 -0.000464  0.095558
```

But I'm still wondering why this is neccessary as when converting it to a segmented index with `audformat` (`db['emotion'].get(as_segmented=True, allow_nat=False)`), this problem does not happen!

---

TODO:
* add tests

/cc @schruefer 