### PR TITLE
Require audformat>=1.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    audformat >=0.15.3,<2.0.0
+    audformat >=1.0.1,<2.0.0
     audmath >=1.2.1
     audresample >=1.1.0,<2.0.0
 python_requires = >=3.8


### PR DESCRIPTION
Closes #113 

This adds a test for #113 which fails with `audformat==1.0.0` and updates the dependency to `audformat>=1.0.1` to incorporate https://github.com/audeering/audformat/pull/380 which fixes the issue described in #113.