### PR TITLE
Add cache_root argument to Segment.process_index()

### DIFF
--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -509,7 +509,7 @@ class Process:
         the result is stored as
         ``<cache_root>/<hash>.pkl``.
         When called again with the same index,
-        features will be read from the cached file.
+        results will be read from the cached file.
 
         Args:
             index: index with segment information

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -215,6 +215,25 @@ def test_index(tmpdir, num_workers, multiprocessing):
     result = segment.process_signal_from_index(signal, sampling_rate, index)
     pd.testing.assert_index_equal(result, expected)
 
+    # empty index returned by process func
+
+    def process_func(x, sr):
+        return audinterface.utils.signal_index()
+
+    segment = audinterface.Segment(
+        process_func=process_func,
+        sampling_rate=None,
+        resample=False,
+        num_workers=num_workers,
+        multiprocessing=multiprocessing,
+        verbose=False,
+    )
+
+    index = pd.Index([path], name='file')
+    expected = audformat.segmented_index()
+    result = segment.process_index(index)
+    pd.testing.assert_index_equal(result, expected)
+
 
 @pytest.mark.parametrize(
     'signal, sampling_rate, segment_func, result',


### PR DESCRIPTION
Closes #118 

Add `cache_root` argument to `audinterface.Segment.process_index()` to cache the result
as we also provide for the `audinterface.Process` and `audinterface.Feature`.

![image](https://github.com/audeering/audinterface/assets/173624/4052dcab-c4a8-45e7-85d2-662989015e98)
