### PR TITLE
Fix rounding of start/end in utils.read_signal()

### DIFF
--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -133,23 +133,21 @@ def read_audio(
     if root is not None and not os.path.isabs(file):
         file = os.path.join(root, file)
 
-    sampling_rate = af.sampling_rate(file)
-
     if start is None or pd.isna(start):
         offset = 0
     else:
-        offset = to_samples(start, sampling_rate)
+        offset = start.total_seconds()
 
     if end is None or pd.isna(end):
         duration = None
     else:
-        duration = to_samples(end, sampling_rate) - offset
+        duration = end.total_seconds() - offset
 
     signal, sampling_rate = af.read(
         audeer.safe_path(file),
         always_2d=True,
-        offset=str(offset),  # str() to enforce samples as unit
-        duration=str(duration),
+        offset=offset,
+        duration=duration,
     )
 
     return signal, sampling_rate
@@ -164,9 +162,9 @@ def segment_to_indices(
     if pd.isna(end):
         end = pd.to_timedelta(signal.shape[-1] / sampling_rate, unit='s')
     max_i = signal.shape[-1]
-    start_i = to_samples(start, sampling_rate)
+    start_i = audmath.samples(start.total_seconds(), sampling_rate)
     start_i = min(start_i, max_i)
-    end_i = to_samples(end, sampling_rate)
+    end_i = audmath.samples(end.total_seconds(), sampling_rate)
     end_i = min(end_i, max_i)
     return start_i, end_i
 
@@ -387,23 +385,6 @@ def to_array(value: typing.Any) -> np.ndarray:
         elif is_scalar(value):
             value = np.array([value])
     return value
-
-
-def to_samples(
-        duration: pd.Timedelta,
-        sampling_rate: int,
-) -> int:
-    r"""Convert duration to samples.
-
-    Args:
-        duration: duration in seconds
-        sampling_rate: sampling rate in Hz
-
-    Returns:
-        duration in samples
-
-    """
-    return int(round(duration.total_seconds() * sampling_rate))
 
 
 def to_timedelta(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ classifiers = [
 requires-python = '>=3.8'
 dependencies = [
     'audformat >=1.0.1,<2.0.0',
-    'audmath >=1.2.1',
+    'audiofile >=1.3.0',
+    'audmath >=1.3.0',
     'audresample >=1.1.0,<2.0.0',
 ]
 # Get version dynamically from git

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -366,13 +366,9 @@ def test_process_file(
         start=start,
         end=end,
     )
-    if isinstance(y.values, np.ndarray):
-        values = y.values[0]
-    else:
-        values = y.values
 
     np.testing.assert_almost_equal(
-        values, expected_output, decimal=4,
+        y.values[0], expected_output, decimal=4,
     )
 
     # test relative path
@@ -382,13 +378,9 @@ def test_process_file(
         end=end,
         root=root,
     )
-    if isinstance(y.values, np.ndarray):
-        values = y.values[0]
-    else:
-        values = y.values
 
     np.testing.assert_almost_equal(
-        values, expected_output, decimal=4,
+        y.values[0], expected_output, decimal=4,
     )
 
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -306,7 +306,8 @@ def signal_modification(signal, sampling_rate, subtract=False):
             False,
             1.0,
         ),
-        # Add failing test for certain `start`, `end` values
+        # Test for certain `start`, `end` values
+        # that were failing before
         # https://github.com/audeering/audinterface/issues/123
         (
             identity,
@@ -325,7 +326,7 @@ def signal_modification(signal, sampling_rate, subtract=False):
             True,
             None,
             False,
-            np.ones((1, 6720)),
+            np.ones((1, 6720), 'float32'),
         ),
     ],
 )
@@ -365,8 +366,13 @@ def test_process_file(
         start=start,
         end=end,
     )
+    if isinstance(y.values, np.ndarray):
+        values = y.values[0]
+    else:
+        values = y.values
+
     np.testing.assert_almost_equal(
-        y.values, expected_output, decimal=4,
+        values, expected_output, decimal=4,
     )
 
     # test relative path
@@ -376,8 +382,13 @@ def test_process_file(
         end=end,
         root=root,
     )
+    if isinstance(y.values, np.ndarray):
+        values = y.values[0]
+    else:
+        values = y.values
+
     np.testing.assert_almost_equal(
-        y.values, expected_output, decimal=4,
+        values, expected_output, decimal=4,
     )
 
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -13,6 +13,10 @@ import audobject
 import audinterface
 
 
+def identity(signal, sampling_rate):
+    return signal
+
+
 def signal_duration(signal, sampling_rate):
     return signal.shape[1] / sampling_rate
 
@@ -301,6 +305,27 @@ def signal_modification(signal, sampling_rate, subtract=False):
             None,
             False,
             1.0,
+        ),
+        # Add failing test for certain `start`, `end` values
+        # https://github.com/audeering/audinterface/issues/123
+        (
+            identity,
+            None,
+            np.concatenate(
+                [
+                    np.zeros((1, 18240)),
+                    np.ones((1, 6720)),
+                    np.zeros((1, 23040)),
+                ],
+                axis=1,
+            ),
+            16000,
+            pd.Timedelta('0 days 00:00:01.140000'),
+            pd.Timedelta('0 days 00:00:01.560000'),
+            True,
+            None,
+            False,
+            np.ones((1, 6720)),
         ),
     ],
 )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,9 +4,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
+import audeer
 import audformat
 
 import audinterface
+import audiofile
 
 
 def to_array(value):
@@ -130,6 +132,45 @@ def test_create_segmented_index(starts, ends):
             assert index.get_level_values(
                 audformat.define.IndexField.END
             ).tolist() == [pd.NaT] * len(starts)
+
+
+def test_read_audio(tmpdir):
+
+    # Ensures that we apply the same rounding
+    # when reading with `audinterface.utils.read_audio()`
+    # with `start` and `end`
+    # or when using `start` and `end` with `process_signal()`.
+
+    # Use critical `start` and `end` values
+    # as reported in
+    # https://github.com/audeering/audinterface/issues/123
+    start = pd.Timedelta('0 days 00:00:01.140000')
+    end = pd.Timedelta('0 days 00:00:01.560000')
+
+    sampling_rate = 16000
+    signal = np.zeros((1, 3 * sampling_rate))
+
+    # Use `audinterface.core.utils.segment_to_indices()` as ground truth
+    start_i, end_i = audinterface.core.utils.segment_to_indices(
+        signal,
+        sampling_rate,
+        start,
+        end,
+    )
+    signal[:, start_i:end_i] = 0.9
+
+    audio_file = audeer.path(tmpdir, 'signal.wav')
+    audiofile.write(audio_file, signal, sampling_rate)
+
+    signal, _ = audinterface.utils.read_audio(
+        audio_file,
+        start=start,
+        end=end,
+    )
+    expected_signal, _ = audiofile.read(audio_file, always_2d=True)
+    expected_signal = expected_signal[:, start_i:end_i]
+
+    np.testing.assert_array_equal(signal, expected_signal)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,9 +6,9 @@ import pytest
 
 import audeer
 import audformat
+import audiofile
 
 import audinterface
-import audiofile
 
 
 def to_array(value):


### PR DESCRIPTION
Closes #123 

For certain values of `start` and `end` `process_file(..., start=start, end=end)` returned a different result than `process_signal(..., start=start, end=end)` as the duration values were rounded differently inside `audinterface.utils.read_audio()`, which is used in `process_file()`.

The behavior is now fixed inside ` audinterface.utils.read_signal()` and `process_file()` returns now the same results as `process_signal()`.

The fix uses `audmath.samples()` as a ground truth for converting to samples and relies on the fix of `audiofile` to also use `audmath.samples()` as ground truth (https://github.com/audeering/audiofile/pull/124).

Beside the fix, this pull request also adds two tests that fail for the current implementation in `main`.