### PR TITLE
CI: update publish Action to pyproject.toml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine virtualenv
 
     # PyPI package
     - name: Build and publish
@@ -29,7 +29,7 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         python -m twine upload dist/*
 
     # Documentation


### PR DESCRIPTION
We updated to use `pyproject.toml` in https://github.com/audeering/audinterface/pull/125, but forgot to update the `publish` Action accordingly.