### PR TITLE
CI: re-enable linkcheck and fix link

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -45,5 +45,5 @@ jobs:
     - name: Test building documentation
       run: python -m sphinx docs/ docs/_build/ -b html -W
 
-    # - name: Check links in documentation
-    #   run: python -m sphinx docs/ docs/_build/ -b linkcheck -W
+    - name: Check links in documentation
+      run: python -m sphinx docs/ docs/_build/ -b linkcheck -W

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ to audio files or databases_.
 Have a look at the installation_ and usage_ instructions.
 
 .. _databases: https://audeering.github.io/audformat/
-.. _installation: https://audeering.github.io/audinterface/install.html
+.. _installation: https://audeering.github.io/audinterface/installation.html
 .. _usage: https://audeering.github.io/audinterface/usage.html
 
 


### PR DESCRIPTION
Re-enable checking for links and fix link to installation section in README.