### PR TITLE
CI: fix changelog stage of publish Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
         CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
         CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
         echo "Got changelog: $CHANGELOG"
-        run echo "body=$CHANGELOG" >> $GITHUB_OUTPUT
+        echo "body=$CHANGELOG" >> $GITHUB_OUTPUT
 
     - name: Create release on Github
       id: create_release


### PR DESCRIPTION
There was a typo that caused https://github.com/audeering/audinterface/actions/runs/5541866055/jobs/10115828195