### PR TITLE
Fix order of start/end values in audinterface.Segment

### DIFF
--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -465,6 +465,12 @@ class Segment:
         ).values[0]
         utils.assert_index(index)
         if start is not None:
+            start = utils.to_timedelta(start)
+            # Here we change directly the levels,
+            # so we need to use
+            # `index.levels[0]`
+            # instead of
+            # `index.get_level_values('start')`
             index = index.set_levels(
                 [
                     index.levels[0] + start,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -418,6 +418,7 @@ class Segment:
             files.extend([file] * len(index))
             starts.extend(index.get_level_values('start') + start)
             ends.extend(index.get_level_values('end') + start)
+
         return audformat.segmented_index(files, starts, ends)
 
     def process_signal(

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -416,8 +416,8 @@ class Segment:
         ends = []
         for (file, start, _), index in y.items():
             files.extend([file] * len(index))
-            starts.extend(index.levels[0] + start)
-            ends.extend(index.levels[1] + start)
+            starts.extend(index.get_level_values('start') + start)
+            ends.extend(index.get_level_values('end') + start)
         return audformat.segmented_index(files, starts, ends)
 
     def process_signal(

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -324,8 +324,8 @@ class Segment:
         ends = []
         for (file, start, _), index in y.items():
             files.extend([file] * len(index))
-            starts.extend(index.levels[0] + start)
-            ends.extend(index.levels[1] + start)
+            starts.extend(index.get_level_values('start') + start)
+            ends.extend(index.get_level_values('end') + start)
 
         return audformat.segmented_index(files, starts, ends)
 

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -272,8 +272,8 @@ class Segment:
         ).values[0]
         return audformat.segmented_index(
             files=[file] * len(index),
-            starts=index.levels[0] + start,
-            ends=index.levels[1] + start,
+            starts=index.get_level_values('start') + start,
+            ends=index.get_level_values('end') + start,
         )
 
     def process_files(

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -418,7 +418,6 @@ class Segment:
             files.extend([file] * len(index))
             starts.extend(index.levels[0] + start)
             ends.extend(index.levels[1] + start)
-
         return audformat.segmented_index(files, starts, ends)
 
     def process_signal(
@@ -476,9 +475,10 @@ class Segment:
         if file is not None:
             index = audformat.segmented_index(
                 files=[file] * len(index),
-                starts=index.levels[0],
-                ends=index.levels[1],
+                starts=index.get_level_values('start'),
+                ends=index.get_level_values('end'),
             )
+
         return index
 
     def process_signal_from_index(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1526,14 +1526,14 @@ def test_process_with_special_args(tmpdir):
     # using audinterface.utils.signal_index()
     'starts, ends',
     [
-        (None, None),
-        (0, 1.5),
-        (1.5, 3),
-        ([0, 1.5], [1.5, 3]),
+        #(None, None),
+        #(0, 1.5),
+        #(1.5, 3),
+        #([0, 1.5], [1.5, 3]),
         # Blocked by https://github.com/audeering/audinterface/issues/134
         # or a similar issue
         # ([0, 1.5], [1, 2.000000003]),
-        ([0, 2], [1, 3]),
+        #([0, 2], [1, 3]),
         # https://github.com/audeering/audinterface/issues/135
         ([0, 1], [3, 2]),
     ]
@@ -1554,6 +1554,8 @@ def test_process_with_segment(tmpdir, starts, ends):
     else:
         files = ['file.wav'] * len(audeer.to_list(starts))
     expected = audformat.segmented_index(files, starts, ends)
+
+    print(f'{expected.get_level_values("end")=}')
 
     # Create signal and file
     sampling_rate = 8000
@@ -1592,6 +1594,8 @@ def test_process_with_segment(tmpdir, starts, ends):
 
     # process file
     index = segment.process_file(file, root=root)
+    pd.testing.assert_index_equal(index, expected)
+
     pd.testing.assert_series_equal(
         process.process_index(index, root=root, preserve_index=True),
         process_with_segment.process_file(file, root=root)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1535,6 +1535,7 @@ def test_process_with_special_args(tmpdir):
         # ([0, 1.5], [1, 2.000000003]),
         #([0, 2], [1, 3]),
         # https://github.com/audeering/audinterface/issues/135
+        ([0, 1], [2, 2]),
         ([0, 1], [3, 2]),
     ]
 )
@@ -1554,6 +1555,7 @@ def test_process_with_segment(tmpdir, starts, ends):
     else:
         files = ['file.wav'] * len(audeer.to_list(starts))
     expected = audformat.segmented_index(files, starts, ends)
+    expected_signal_index = audinterface.utils.signal_index(starts, ends)
 
     print(f'{expected.get_level_values("end")=}')
 
@@ -1566,11 +1568,15 @@ def test_process_with_segment(tmpdir, starts, ends):
     audiofile.write(path, signal, sampling_rate)
 
     # process signal
-    index = segment.process_signal(
-        signal,
-        sampling_rate,
-        file=file,
-    )
+    index = segment.process_signal(signal, sampling_rate)
+    pd.testing.assert_index_equal(index, expected_signal_index)
+
+    # process signal with start argument
+    index = segment.process_signal(signal, sampling_rate, start=0)
+    pd.testing.assert_index_equal(index, expected_signal_index)
+
+    # process signal with file argument
+    index = segment.process_signal(signal, sampling_rate, file=file)
     pd.testing.assert_index_equal(index, expected)
 
     pd.testing.assert_series_equal(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1528,10 +1528,10 @@ def test_process_with_special_args(tmpdir):
         ),
         audinterface.Segment(
             process_func=lambda x, sr:
-                audinterface.utils.signal_index(
-                    pd.to_timedelta(0),
-                    pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                )
+            audinterface.utils.signal_index(
+                pd.to_timedelta(0),
+                pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
+            )
         ),
         audinterface.Segment(
             process_func=lambda x, sr:
@@ -1542,17 +1542,26 @@ def test_process_with_special_args(tmpdir):
         ),
         audinterface.Segment(
             process_func=lambda x, sr:
-                audinterface.utils.signal_index(
-                    [
-                        pd.to_timedelta(0),
-                        pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                    ],
-                    [
-                        pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                        pd.to_timedelta(x.shape[1] / sr),
-                    ],
-                )
-        )
+            audinterface.utils.signal_index(
+                [
+                    pd.to_timedelta(0),
+                    pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
+                ],
+                [
+                    pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
+                    pd.to_timedelta(x.shape[1] / sr),
+                ],
+            )
+        ),
+        audinterface.Segment(
+            process_func=lambda x, sr:
+            audinterface.utils.signal_index([0, 2], [1, 3])
+        ),
+        # https://github.com/audeering/audinterface/issues/135
+        audinterface.Segment(
+            process_func=lambda x, sr:
+            audinterface.utils.signal_index([0, 1], [3, 2])
+        ),
     ]
 )
 def test_process_with_segment(tmpdir, segment):
@@ -1576,6 +1585,21 @@ def test_process_with_segment(tmpdir, segment):
         sampling_rate,
         file=file,
     )
+    print(f'{index.get_level_values("start")=}')
+    print(f'{index.get_level_values("end")=}')
+
+    i1 = process.process_index(index, root=root)
+    print(f'{i1.index.get_level_values("start")=}')
+    print(f'{i1.index.get_level_values("end")=}')
+
+    i2 = process_with_segment.process_signal(
+        signal,
+        sampling_rate,
+        file=file,
+    )
+    print(f'{i2.index.get_level_values("start")=}')
+    print(f'{i2.index.get_level_values("end")=}')
+
     pd.testing.assert_series_equal(
         process.process_index(index, root=root),
         process_with_segment.process_signal(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1520,51 +1520,87 @@ def test_process_with_special_args(tmpdir):
     pd.testing.assert_series_equal(y, expected)
 
 
+#@pytest.mark.parametrize(
+#    'segment, expected',
+#    [
+#        # audinterface.Segment(
+#        #     process_func=lambda x, sr: audinterface.utils.signal_index()
+#        # ),
+#        # audinterface.Segment(
+#        #     process_func=lambda x, sr:
+#        #     audinterface.utils.signal_index(
+#        #         pd.to_timedelta(0),
+#        #         pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
+#        #     )
+#        # ),
+#        # audinterface.Segment(
+#        #     process_func=lambda x, sr:
+#        #     audinterface.utils.signal_index(
+#        #         pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
+#        #         pd.to_timedelta(x.shape[1] / sr, unit='s'),
+#        #     )
+#        # ),
+#        # audinterface.Segment(
+#        #     process_func=lambda x, sr:
+#        #     audinterface.utils.signal_index(
+#        #         [
+#        #             pd.to_timedelta(0),
+#        #             pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
+#        #         ],
+#        #         [
+#        #             pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
+#        #             pd.to_timedelta(x.shape[1] / sr),
+#        #         ],
+#        #     )
+#        # ),
+#        # audinterface.Segment(
+#        #     process_func=lambda x, sr:
+#        #     audinterface.utils.signal_index([0, 2], [1, 3])
+#        # ),
+#        # https://github.com/audeering/audinterface/issues/135
+#        (
+#            audinterface.Segment(
+#                process_func=lambda x, sr:
+#                audinterface.utils.signal_index([0, 1], [3, 2])
+#            ),
+#            pd.MultiIndex.from_arrays(
+#                [
+#                    [
+#                        pd.Timedelta('0 days 00:00:00'),
+#                        pd.Timedelta('0 days 00:00:01'),
+#                    ],
+#                    [
+#                        pd.Timedelta('0 days 00:00:03'),
+#                        pd.Timedelta('0 days 00:00:02'),
+#                    ],
+#                ],
+#                names=['start', 'end'],
+#            ),
+#        ),
+#    ]
+#)
 @pytest.mark.parametrize(
-    'segment',
+    'starts, ends',
     [
-        audinterface.Segment(
-            process_func=lambda x, sr: audinterface.utils.signal_index()
-        ),
-        audinterface.Segment(
-            process_func=lambda x, sr:
-            audinterface.utils.signal_index(
-                pd.to_timedelta(0),
-                pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-            )
-        ),
-        audinterface.Segment(
-            process_func=lambda x, sr:
-            audinterface.utils.signal_index(
-                pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                pd.to_timedelta(x.shape[1] / sr, unit='s'),
-            )
-        ),
-        audinterface.Segment(
-            process_func=lambda x, sr:
-            audinterface.utils.signal_index(
-                [
-                    pd.to_timedelta(0),
-                    pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                ],
-                [
-                    pd.to_timedelta(x.shape[1] / sr, unit='s') / 2,
-                    pd.to_timedelta(x.shape[1] / sr),
-                ],
-            )
-        ),
-        audinterface.Segment(
-            process_func=lambda x, sr:
-            audinterface.utils.signal_index([0, 2], [1, 3])
-        ),
+        ([0, 2], [1, 3]),
         # https://github.com/audeering/audinterface/issues/135
-        audinterface.Segment(
-            process_func=lambda x, sr:
-            audinterface.utils.signal_index([0, 1], [3, 2])
-        ),
+        ([0, 1], [3, 2]),
     ]
 )
-def test_process_with_segment(tmpdir, segment):
+def test_process_with_segment(tmpdir, starts, ends):
+
+    segment = audinterface.Segment(
+        process_func=lambda x, sr:
+        audinterface.utils.signal_index(starts, ends)
+    )
+
+    expected = audformat.segmented_index(
+        files=['file.wav'] * len(starts),
+        starts=starts,
+        ends=ends,
+    )
+    print(expected)
+    print(f'{expected.get_level_values("end")=}')
 
     process = audinterface.Process()
     process_with_segment = audinterface.Process(
@@ -1573,7 +1609,8 @@ def test_process_with_segment(tmpdir, segment):
 
     # create signal and file
     sampling_rate = 8000
-    signal = np.zeros((1, sampling_rate))
+    # TODO: make another issue for the case of a shorter signal
+    signal = np.zeros((1, 3 * sampling_rate))
     root = tmpdir
     file = 'file.wav'
     path = os.path.join(root, file)
@@ -1585,12 +1622,8 @@ def test_process_with_segment(tmpdir, segment):
         sampling_rate,
         file=file,
     )
-    print(f'{index.get_level_values("start")=}')
-    print(f'{index.get_level_values("end")=}')
 
-    i1 = process.process_index(index, root=root)
-    print(f'{i1.index.get_level_values("start")=}')
-    print(f'{i1.index.get_level_values("end")=}')
+    pd.testing.assert_index_equal(index, expected)
 
     i2 = process_with_segment.process_signal(
         signal,
@@ -1608,6 +1641,7 @@ def test_process_with_segment(tmpdir, segment):
             file=file,
         )
     )
+    assert False
     index = segment.process_signal_from_index(
         signal,
         sampling_rate,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1526,16 +1526,16 @@ def test_process_with_special_args(tmpdir):
     # using audinterface.utils.signal_index()
     'starts, ends',
     [
-        #(None, None),
-        #(0, 1.5),
-        #(1.5, 3),
-        #([0, 1.5], [1.5, 3]),
+        (None, None),
+        (0, 1.5),
+        (1.5, 3),
+        ([0, 1.5], [1.5, 3]),
         # Blocked by https://github.com/audeering/audinterface/issues/134
         # or a similar issue
         # ([0, 1.5], [1, 2.000000003]),
-        #([0, 2], [1, 3]),
-        # https://github.com/audeering/audinterface/issues/135
+        ([0, 2], [1, 3]),
         ([0, 1], [2, 2]),
+        # https://github.com/audeering/audinterface/issues/135
         ([0, 1], [3, 2]),
     ]
 )
@@ -1584,20 +1584,6 @@ def test_process_with_segment(tmpdir, starts, ends):
         process_with_segment.process_signal(signal, sampling_rate, file=file)
     )
 
-    index = segment.process_signal_from_index(
-        signal,
-        sampling_rate,
-        audformat.filewise_index(file),
-    )
-    pd.testing.assert_series_equal(
-        process.process_index(index, root=root, preserve_index=True),
-        process_with_segment.process_signal_from_index(
-            signal,
-            sampling_rate,
-            audformat.filewise_index(file),
-        )
-    )
-
     # process signal from index
     index = segment.process_signal_from_index(
         signal,
@@ -1611,6 +1597,21 @@ def test_process_with_segment(tmpdir, starts, ends):
         audformat.segmented_index(file, 0, 3),
     )
     pd.testing.assert_index_equal(index, expected)
+    index = segment.process_signal_from_index(
+        signal,
+        sampling_rate,
+        audformat.filewise_index(file),
+    )
+    pd.testing.assert_index_equal(index, expected)
+
+    pd.testing.assert_series_equal(
+        process.process_index(index, root=root, preserve_index=True),
+        process_with_segment.process_signal_from_index(
+            signal,
+            sampling_rate,
+            audformat.filewise_index(file),
+        )
+    )
 
     # process file
     index = segment.process_file(file, root=root)
@@ -1620,22 +1621,12 @@ def test_process_with_segment(tmpdir, starts, ends):
         process.process_index(index, root=root, preserve_index=True),
         process_with_segment.process_file(file, root=root)
     )
-    index = segment.process_index(
-        audformat.filewise_index(file),
-        root=root,
-    )
-    pd.testing.assert_series_equal(
-        process.process_index(index, root=root, preserve_index=True),
-        process_with_segment.process_index(
-            audformat.filewise_index(file),
-            root=root,
-        )
-    )
 
     # process files
     index = segment.process_files([file], root=root)
     pd.testing.assert_index_equal(index, expected)
 
+    # https://github.com/audeering/audinterface/issues/138
     # pd.testing.assert_series_equal(
     #     process.process_index(index, root=root, preserve_index=True),
     #     process_with_segment.process_files([file], root=root)
@@ -1645,6 +1636,13 @@ def test_process_with_segment(tmpdir, starts, ends):
     index = segment.process_index(audformat.filewise_index(file), root=root)
     pd.testing.assert_index_equal(index, expected)
 
+    pd.testing.assert_series_equal(
+        process.process_index(index, root=root, preserve_index=True),
+        process_with_segment.process_index(
+            audformat.filewise_index(file),
+            root=root,
+        )
+    )
 
 def test_read_audio(tmpdir):
     sampling_rate = 8000

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1612,6 +1612,15 @@ def test_process_with_segment(tmpdir, starts, ends):
         )
     )
 
+    # process files
+    index = segment.process_files([file], root=root)
+    pd.testing.assert_index_equal(index, expected)
+
+    # pd.testing.assert_series_equal(
+    #     process.process_index(index, root=root, preserve_index=True),
+    #     process_with_segment.process_files([file], root=root)
+    # )
+
 
 def test_read_audio(tmpdir):
     sampling_rate = 8000

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1598,6 +1598,20 @@ def test_process_with_segment(tmpdir, starts, ends):
         )
     )
 
+    # process signal from index
+    index = segment.process_signal_from_index(
+        signal,
+        sampling_rate,
+        audinterface.utils.signal_index(0, 3),
+    )
+    pd.testing.assert_index_equal(index, expected_signal_index)
+    index = segment.process_signal_from_index(
+        signal,
+        sampling_rate,
+        audformat.segmented_index(file, 0, 3),
+    )
+    pd.testing.assert_index_equal(index, expected)
+
     # process file
     index = segment.process_file(file, root=root)
     pd.testing.assert_index_equal(index, expected)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -8,6 +8,7 @@ import audeer
 import audformat
 import audiofile
 import audiofile as af
+import audmath
 import audobject
 
 import audinterface
@@ -1551,7 +1552,13 @@ def test_process_with_segment(tmpdir, starts, ends):
 
     # Create signal and file
     sampling_rate = 8000
-    signal = np.zeros((1, 3 * sampling_rate))
+    if ends is None:
+        duration = 1
+    else:
+        duration = audmath.duration_in_seconds(
+            max(audeer.to_list(ends))
+        )
+    signal = np.zeros((1, audmath.samples(duration, sampling_rate)))
     root = tmpdir
     file = 'file.wav'
     path = os.path.join(root, file)
@@ -1567,8 +1574,6 @@ def test_process_with_segment(tmpdir, starts, ends):
     expected = audformat.segmented_index(files, starts, ends)
     expected_folder_index = audformat.segmented_index(files_abs, starts, ends)
     expected_signal_index = audinterface.utils.signal_index(starts, ends)
-
-    print(f'{expected.get_level_values("end")=}')
 
     # process signal
     index = segment.process_signal(signal, sampling_rate)
@@ -1591,13 +1596,13 @@ def test_process_with_segment(tmpdir, starts, ends):
     index = segment.process_signal_from_index(
         signal,
         sampling_rate,
-        audinterface.utils.signal_index(0, 3),
+        audinterface.utils.signal_index(0, duration),
     )
     pd.testing.assert_index_equal(index, expected_signal_index)
     index = segment.process_signal_from_index(
         signal,
         sampling_rate,
-        audformat.segmented_index(file, 0, 3),
+        audformat.segmented_index(file, 0, duration),
     )
     pd.testing.assert_index_equal(index, expected)
     index = segment.process_signal_from_index(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1621,6 +1621,10 @@ def test_process_with_segment(tmpdir, starts, ends):
     #     process_with_segment.process_files([file], root=root)
     # )
 
+    # process index
+    index = segment.process_index(audformat.filewise_index(file), root=root)
+    pd.testing.assert_index_equal(index, expected)
+
 
 def test_read_audio(tmpdir):
     sampling_rate = 8000


### PR DESCRIPTION
Closes #135 

In `audinterace.Segment` the process functions return an index, which in most cases is generated at the end of the involved process function. Usually, this involves requesting `starts` and `ends` values from previous processing steps. In some cases these were wrongly done by `index.levels` instead of `index.get_level_values()`.

This expands the tests and fixes the underlying issue.