### PR TITLE
Fix precision of audinterface.utils.to_timedelta()

### DIFF
--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -459,16 +459,18 @@ def to_timedelta(
     ):
         # sequence of duration entries
         durations = [
-            duration_in_seconds(duration, sampling_rate)
+            to_timedelta(duration, sampling_rate)
             for duration in durations
         ]
     else:
         # single duration entry
+        if isinstance(durations, pd.Timedelta):
+            return durations
+
         durations = duration_in_seconds(durations, sampling_rate)
+        durations = pd.to_timedelta(durations, unit='s')
 
-    durations = pd.to_timedelta(durations, unit='s')
-
-    if isinstance(durations, pd.TimedeltaIndex):
-        durations = list(durations)
+    # if isinstance(durations, pd.TimedeltaIndex):
+    #     durations = list(durations)
 
     return durations

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -464,13 +464,13 @@ def to_timedelta(
         ]
     else:
         # single duration entry
+
+        # avoid converting Timedelta values to ensure precision
+        # https://github.com/audeering/audinterface/pull/137
         if isinstance(durations, pd.Timedelta):
             return durations
 
         durations = duration_in_seconds(durations, sampling_rate)
         durations = pd.to_timedelta(durations, unit='s')
-
-    # if isinstance(durations, pd.TimedeltaIndex):
-    #     durations = list(durations)
 
     return durations

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -174,6 +174,52 @@ def test_read_audio(tmpdir):
 
 
 @pytest.mark.parametrize(
+    'starts, ends, expected',
+    [
+        (
+            [1, 2],
+            [3, 4],
+            pd.MultiIndex.from_arrays(
+                [
+                    pd.TimedeltaIndex(
+                        [
+                            pd.Timedelta('0 days 00:00:01.0'),
+                            pd.Timedelta('0 days 00:00:02.0'),
+                        ]
+                    ),
+                    pd.TimedeltaIndex(
+                        [
+                            pd.Timedelta('0 days 00:00:03.0'),
+                            pd.Timedelta('0 days 00:00:04.0'),
+                        ]
+                    ),
+                ],
+                names=['start', 'end'],
+            ),
+        ),
+        (
+            [pd.Timedelta('0 days 00:00:35.511437999')],
+            [36],
+            pd.MultiIndex.from_arrays(
+                [
+                    pd.TimedeltaIndex(
+                        [pd.Timedelta('0 days 00:00:35.511437999')]
+                    ),
+                    pd.TimedeltaIndex(
+                        [pd.Timedelta('0 days 00:00:36.000000000')]
+                    ),
+                ],
+                names=['start', 'end'],
+            ),
+        ),
+    ]
+)
+def test_signal_index(starts, ends, expected):
+    index = audinterface.utils.signal_index(starts, ends)
+    pd.testing.assert_index_equal(index, expected)
+
+
+@pytest.mark.parametrize(
     'signal, sampling_rate, win_dur, hop_dur, expected',
     [
         # empty
@@ -409,6 +455,23 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
         hop_dur,
     )
     np.testing.assert_equal(frames, expected)
+
+
+@pytest.mark.parametrize(
+    'duration, expected',
+    [
+        (
+            10,
+            pd.to_timedelta(10, unit='s'),
+        ),
+        (  # See https://github.com/audeering/audinterface/issues/134
+            pd.Timedelta('0 days 00:00:35.511437999'),
+            pd.Timedelta('0 days 00:00:35.511437999'),
+        ),
+    ]
+)
+def test_to_timedelta(duration, expected):
+    assert audinterface.utils.to_timedelta(duration) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -177,20 +177,31 @@ def test_read_audio(tmpdir):
     'starts, ends, expected',
     [
         (
+            1,
+            2,
+            pd.MultiIndex.from_arrays(
+                [
+                    pd.TimedeltaIndex([pd.Timedelta('0 days 00:00:01')]),
+                    pd.TimedeltaIndex([pd.Timedelta('0 days 00:00:02')]),
+                ],
+                names=['start', 'end'],
+            ),
+        ),
+        (
             [1, 2],
             [3, 4],
             pd.MultiIndex.from_arrays(
                 [
                     pd.TimedeltaIndex(
                         [
-                            pd.Timedelta('0 days 00:00:01.0'),
-                            pd.Timedelta('0 days 00:00:02.0'),
+                            pd.Timedelta('0 days 00:00:01'),
+                            pd.Timedelta('0 days 00:00:02'),
                         ]
                     ),
                     pd.TimedeltaIndex(
                         [
-                            pd.Timedelta('0 days 00:00:03.0'),
-                            pd.Timedelta('0 days 00:00:04.0'),
+                            pd.Timedelta('0 days 00:00:03'),
+                            pd.Timedelta('0 days 00:00:04'),
                         ]
                     ),
                 ],
@@ -206,7 +217,7 @@ def test_read_audio(tmpdir):
                         [pd.Timedelta('0 days 00:00:35.511437999')]
                     ),
                     pd.TimedeltaIndex(
-                        [pd.Timedelta('0 days 00:00:36.000000000')]
+                        [pd.Timedelta('0 days 00:00:36')]
                     ),
                 ],
                 names=['start', 'end'],
@@ -464,9 +475,30 @@ def test_sliding_window(signal, sampling_rate, win_dur, hop_dur, expected):
             10,
             pd.to_timedelta(10, unit='s'),
         ),
-        (  # See https://github.com/audeering/audinterface/issues/134
+        (
+            [1],
+            [pd.Timedelta('0 days 00:00:01')],
+        ),
+        (
+            [1, 2],
+            [pd.Timedelta('0 days 00:00:01'), pd.Timedelta('0 days 00:00:02')],
+        ),
+        (
+            [1, pd.Timedelta('0 days 00:00:02')],
+            [pd.Timedelta('0 days 00:00:01'), pd.Timedelta('0 days 00:00:02')],
+        ),
+        # Example with high precision
+        # https://github.com/audeering/audinterface/issues/134
+        (
             pd.Timedelta('0 days 00:00:35.511437999'),
             pd.Timedelta('0 days 00:00:35.511437999'),
+        ),
+        (
+            [1e-09, 1],
+            [
+                pd.Timedelta('0 days 00:00:00.000000001'),
+                pd.Timedelta('0 days 00:00:01'),
+            ],
         ),
     ]
 )


### PR DESCRIPTION
Closes #134 

~~Blocked by #135~~

When providing the time already as `pd.Timedelta` we have to ensure that we do not loose precision (compare https://github.com/audeering/audinterface/issues/113). The easiest way to achieve this is to check if the type is already `pd.Timedelta` and not convert in that case.