### PR TITLE
Fix Process.process_files() with segment object

### DIFF
--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -373,6 +373,15 @@ class Process:
         if len(files) == 0:
             return pd.Series(dtype=object)
 
+        if self.segment is not None:
+            index = self.segment.process_files(
+                files,
+                starts=starts,
+                ends=ends,
+                root=root,
+            )
+            return self._process_index_wo_segment(index, root)
+
         if isinstance(starts, (type(None), float, int, str, pd.Timedelta)):
             starts = [starts] * len(files)
         if isinstance(ends, (type(None), float, int, str, pd.Timedelta)):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1635,10 +1635,10 @@ def test_process_with_segment(tmpdir, starts, ends):
     pd.testing.assert_index_equal(index, expected)
 
     # https://github.com/audeering/audinterface/issues/138
-    # pd.testing.assert_series_equal(
-    #     process.process_index(index, root=root, preserve_index=True),
-    #     process_with_segment.process_files([file], root=root)
-    # )
+    pd.testing.assert_series_equal(
+        process.process_index(index, root=root, preserve_index=True),
+        process_with_segment.process_files([file], root=root)
+    )
 
     # process folder
     index = segment.process_folder(root)


### PR DESCRIPTION
Closes #138 

Ensures the `segment` object is not ignored when calling `audinterface.Process.process_files()`.