### PR TITLE
TST: test process_folder() for empty segment index

### DIFF
--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1645,10 +1645,10 @@ def test_process_with_segment(tmpdir, starts, ends):
     pd.testing.assert_index_equal(index, expected_folder_index)
 
     # https://github.com/audeering/audinterface/issues/139
-    # pd.testing.assert_series_equal(
-    #     process.process_index(index, root=root, preserve_index=True),
-    #     process_with_segment.process_folder(root),
-    # )
+    pd.testing.assert_series_equal(
+        process.process_index(index, root=root, preserve_index=True),
+        process_with_segment.process_folder(root),
+    )
 
     # process index
     index = segment.process_index(audformat.filewise_index(file), root=root)


### PR DESCRIPTION
Closes #139 

With https://github.com/audeering/audinterface/pull/141 we also fixed #139 and `process_folder()` now returns an empty index, if the underlying `segment` object returns an empty index:

```python
# execute first code from #139 
>>> process.process_folder('.').index
MultiIndex([], names=['file', 'start', 'end'])

```

In this merge request we just enable a test that was failing before #141 was merged.