### PR TITLE
Add include_root argument to process_folder()

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -480,6 +480,7 @@ class Feature:
             root: str,
             *,
             filetype: str = 'wav',
+            include_root: bool = True,
     ) -> pd.DataFrame:
         r"""Extract features from files in a folder.
 
@@ -488,6 +489,10 @@ class Feature:
         Args:
             root: root folder
             filetype: file extension
+            include_root: if ``True``
+                the file paths are absolute
+                in the index
+                of the returned result
 
         Raises:
             FileNotFoundError: if folder does not exist
@@ -505,9 +510,12 @@ class Feature:
                 root,
             )
 
-        files = audeer.list_file_names(root, filetype=filetype)
-        files = [os.path.join(root, os.path.basename(f)) for f in files]
-        return self.process_files(files)
+        files = audeer.list_file_names(
+            root,
+            filetype=filetype,
+            basenames=not include_root,
+        )
+        return self.process_files(files, root=root)
 
     def process_index(
             self,

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -427,6 +427,7 @@ class Process:
             root: str,
             *,
             filetype: str = 'wav',
+            include_root: bool = True,
     ) -> pd.Series:
         r"""Process files in a folder.
 
@@ -435,6 +436,10 @@ class Process:
         Args:
             root: root folder
             filetype: file extension
+            include_root: if ``True``
+                the file paths are absolute
+                in the index
+                of the returned result
 
         Returns:
             Series with processed files conform to audformat_
@@ -455,9 +460,12 @@ class Process:
                 root,
             )
 
-        files = audeer.list_file_names(root, filetype=filetype)
-        files = [os.path.join(root, os.path.basename(f)) for f in files]
-        return self.process_files(files)
+        files = audeer.list_file_names(
+            root,
+            filetype=filetype,
+            basenames=not include_root,
+        )
+        return self.process_files(files, root=root)
 
     def _process_index_wo_segment(
             self,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -334,6 +334,7 @@ class Segment:
             root: str,
             *,
             filetype: str = 'wav',
+            include_root: bool = True,
     ) -> pd.Index:
         r"""Segment files in a folder.
 
@@ -342,6 +343,10 @@ class Segment:
         Args:
             root: root folder
             filetype: file extension
+            include_root: if ``True``
+                the file paths are absolute
+                in the index
+                of the returned result
 
         Returns:
             Segmented index conform to audformat_
@@ -362,9 +367,12 @@ class Segment:
                 root,
             )
 
-        files = audeer.list_file_names(root, filetype=filetype)
-        files = [os.path.join(root, os.path.basename(f)) for f in files]
-        return self.process_files(files)
+        files = audeer.list_file_names(
+            root,
+            filetype=filetype,
+            basenames=not include_root,
+        )
+        return self.process_files(files, root=root)
 
     def process_index(
             self,

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -389,15 +389,22 @@ def test_process_folder(tmpdir):
     )
 
     path = str(tmpdir.mkdir('wav'))
-    files = [
-        os.path.join(path, f'file{n}.wav') for n in range(3)
-    ]
-    for file in files:
+    files = [f'file{n}.wav' for n in range(3)]
+    files_abs = [os.path.join(path, file) for file in files]
+    for file in files_abs:
         af.write(file, SIGNAL_2D, SAMPLING_RATE)
 
+    # folder with include_root=True
     y = feature.process_folder(path)
     y_expected = np.ones((3, NUM_CHANNELS * NUM_FEATURES))
+    assert all(y.index.levels[0] == files_abs)
+    assert all(y.index.levels[1] == index.levels[0])
+    assert all(y.index.levels[2] == index.levels[1])
+    np.testing.assert_array_equal(y.values, y_expected)
 
+    # folder with include_root=False
+    y = feature.process_folder(path, include_root=False)
+    y_expected = np.ones((3, NUM_CHANNELS * NUM_FEATURES))
     assert all(y.index.levels[0] == files)
     assert all(y.index.levels[1] == index.levels[0])
     assert all(y.index.levels[2] == index.levels[1])

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1644,10 +1644,19 @@ def test_process_with_segment(tmpdir, starts, ends):
     index = segment.process_folder(root)
     pd.testing.assert_index_equal(index, expected_folder_index)
 
-    # https://github.com/audeering/audinterface/issues/139
     pd.testing.assert_series_equal(
         process.process_index(index, root=root, preserve_index=True),
         process_with_segment.process_folder(root),
+    )
+
+    # process folder without root
+    # https://github.com/audeering/audinterface/issues/139
+    index = segment.process_folder(root, include_root=False)
+    pd.testing.assert_index_equal(index, expected)
+
+    pd.testing.assert_series_equal(
+        process.process_index(index, root=root, preserve_index=True),
+        process_with_segment.process_folder(root, include_root=False),
     )
 
     # process index


### PR DESCRIPTION
Closes #140

This adds the `include_root` argument to
* `audinterface.Process.process_folder()`
* `audinterface.Segment.process_folder()`
* `audinterface.Feature.process_folder()`

If set to `False` it will return the relative path in the resulting index.

![image](https://github.com/audeering/audinterface/assets/173624/058eaa93-e731-491d-ae46-798fa58c2ba8)

![image](https://github.com/audeering/audinterface/assets/173624/3f2fe9c3-117f-4419-af85-44732b094614)

![image](https://github.com/audeering/audinterface/assets/173624/a4d85bff-21d5-4193-b8ac-38866483e3a0)
