### PR TITLE
TST: add tests for segment in argument of Feature

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -767,7 +767,12 @@ class Feature:
     ) -> pd.DataFrame:
 
         if y.empty:
+            if self.process.segment is None:
+                index = []
+            else:
+                index = audformat.segmented_index()
             return pd.DataFrame(
+                index=index,
                 columns=self.column_names,
                 dtype=object,
             )

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -420,6 +420,7 @@ def test_process_folder(tmpdir):
     pd.testing.assert_frame_equal(
         df,
         pd.DataFrame(
+            index=pd.Index([], dtype='object'),
             dtype=object,
             columns=feature.column_names,
         ),


### PR DESCRIPTION
Extends the tests for the process functions of `audinterface.Process` when `segment` object is present to `audinterface.Feature`.

In order to pass the tests the following behavior have changed:
if a `segment` object is present that returns an empty index, `audinterface.Feature.process_*()` no longer returns `Index([], dtype='object')`, but `MultiIndex([], names=['file', 'start', 'end'])`.