### PR TITLE
Fix precision of end values in process_file()

### DIFF
--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 import audeer
 import audformat
+import audmath
 
 from audinterface.core import utils
 from audinterface.core.segment import Segment
@@ -279,6 +280,16 @@ class Process:
                 ends[0] += start
             if self.keep_nat and (end is None or pd.isna(end)):
                 ends[0] = pd.NaT
+            # Ensure we get the same precision for the end values
+            # by storing what is lost due to rounding
+            # when reading the file
+            if end is not None and not pd.isna(end):
+                end_at_sample = utils.to_timedelta(
+                    audmath.samples(end.total_seconds(), sampling_rate)
+                    / sampling_rate
+                )
+                end_precision_difference = end - end_at_sample
+                ends[-1] += end_precision_difference
 
         return y, files, starts, ends
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import numpy as np
+import pytest
+
+import audiofile
+import audmath
+
+
+@pytest.fixture(scope='module')
+def audio(tmpdir_factory, request):
+    """Fixture to generate audio file.
+
+    Provide ``(duration, sampling_rate)``
+    as parameter to this fixture.
+
+    """
+    file = str(tmpdir_factory.mktemp('audio').join('file.wav'))
+    duration, sampling_rate = request.param
+    signal = np.zeros((1, audmath.samples(duration, sampling_rate)))
+    audiofile.write(file, signal, sampling_rate)
+
+    yield file, signal, sampling_rate

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1531,11 +1531,13 @@ def test_process_with_special_args(tmpdir):
         (0, 1.5),
         (1.5, 3),
         ([0, 1.5], [1.5, 3]),
-        # Blocked by https://github.com/audeering/audinterface/issues/134
-        # or a similar issue
-        ([0, 1.5], [1, 2.000000003]),
         ([0, 2], [1, 3]),
         ([0, 1], [2, 2]),
+        # https://github.com/audeering/audinterface/pull/145
+        ([0, 1.5], [1, 2.000000003]),
+        ([0.000000003, 1.5], [1, 2]),
+        ([1.000000003, 1.5], [1.1, 2]),
+        ([1.000000003, 2.1], [2.000000003, 2.5]),
         # https://github.com/audeering/audinterface/issues/135
         ([0, 1], [3, 2]),
     ]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1533,7 +1533,7 @@ def test_process_with_special_args(tmpdir):
         ([0, 1.5], [1.5, 3]),
         # Blocked by https://github.com/audeering/audinterface/issues/134
         # or a similar issue
-        # ([0, 1.5], [1, 2.000000003]),
+        ([0, 1.5], [1, 2.000000003]),
         ([0, 2], [1, 3]),
         ([0, 1], [2, 2]),
         # https://github.com/audeering/audinterface/issues/135

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -8,7 +8,6 @@ import audeer
 import audformat
 import audiofile
 import audiofile as af
-import audmath
 import audobject
 
 import audinterface
@@ -1521,6 +1520,7 @@ def test_process_with_special_args(tmpdir):
     pd.testing.assert_series_equal(y, expected)
 
 
+@pytest.mark.parametrize('audio', [(3, 8000)], indirect=True)  # s, Hz
 @pytest.mark.parametrize(
     # `starts` and `ends`
     # are used to create a segment object
@@ -1542,7 +1542,11 @@ def test_process_with_special_args(tmpdir):
         ([0, 1], [3, 2]),
     ]
 )
-def test_process_with_segment(tmpdir, starts, ends):
+def test_process_with_segment(audio, starts, ends):
+
+    path, signal, sampling_rate = audio
+    root, file = os.path.split(path)
+    duration = signal.shape[1] / sampling_rate
 
     # Segment and process objects
     segment = audinterface.Segment(
@@ -1551,20 +1555,6 @@ def test_process_with_segment(tmpdir, starts, ends):
     )
     process = audinterface.Process()
     process_with_segment = audinterface.Process(segment=segment)
-
-    # Create signal and file
-    sampling_rate = 8000
-    if ends is None:
-        duration = 1
-    else:
-        duration = audmath.duration_in_seconds(
-            max(audeer.to_list(ends))
-        )
-    signal = np.zeros((1, audmath.samples(duration, sampling_rate)))
-    root = tmpdir
-    file = 'file.wav'
-    path = os.path.join(root, file)
-    audiofile.write(path, signal, sampling_rate)
 
     # Expected index
     if starts is None:
@@ -1673,12 +1663,9 @@ def test_process_with_segment(tmpdir, starts, ends):
         ),
     )
 
-def test_read_audio(tmpdir):
-    sampling_rate = 8000
-    signal = np.ones((1, 8000))
-    path = str(tmpdir.mkdir('wav'))
-    file = os.path.join(path, 'file.wav')
-    af.write(file, signal, sampling_rate)
+@pytest.mark.parametrize('audio', [(1, 8000)], indirect=True)  # s, Hz
+def test_read_audio(audio):
+    file, _, sampling_rate = audio
     s, sr = audinterface.utils.read_audio(
         file,
         start=pd.Timedelta('00:00:00.1'),


### PR DESCRIPTION
This is related to https://github.com/audeering/audinterface/issues/134, but has a different cause as the reason we loose precision is not related to calling `to_timedelta()` but due to reading in only a part of the file inside `process_file()` if `start` and `end` are given. The values are then of cause rounded to the nearest sample and we have to save the difference to the original requested values in order to restore the correct values.

---

To reduce the number of times we have to write an audio file, this introduces also an `audio` test fixture, that writes the audio files only once.