### PR TITLE
DOC: require pyarrow

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ auditok
 ipykernel
 jupyter-sphinx
 librosa
+pyarrow
 sphinx
 sphinx-audeering-theme >=1.2.1
 sphinx-autodoc-typehints

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -757,7 +757,7 @@ def test_process_index_filewise_end_times(tmpdir):
             None,
             None,
             False,
-            np.array([1., 2., 3.]),
+            np.array([[1., 2., 3.]]),
         ),
         (
             None,
@@ -769,7 +769,7 @@ def test_process_index_filewise_end_times(tmpdir):
             None,
             None,
             False,
-            np.array([1., 2., 3.]),
+            np.array([[1., 2., 3.]]),
         ),
         (
             None,
@@ -781,7 +781,7 @@ def test_process_index_filewise_end_times(tmpdir):
             None,
             None,
             False,
-            np.array([1., 2.]),
+            np.array([[1., 2.]]),
         ),
         (
             None,
@@ -793,7 +793,7 @@ def test_process_index_filewise_end_times(tmpdir):
             None,
             None,
             False,
-            np.array([1., 2.]),
+            np.array([[1., 2.]]),
         ),
         (
             signal_max,
@@ -993,7 +993,6 @@ def test_process_signal(
         start=start,
         end=end,
     )
-    signal = np.atleast_2d(signal)
     if start is None or pd.isna(start):
         start = pd.to_timedelta(0)
     elif isinstance(start, (int, float)):
@@ -1002,7 +1001,7 @@ def test_process_signal(
         start = pd.to_timedelta(start)
     if end is None or (pd.isna(end) and not keep_nat):
         end = pd.to_timedelta(
-            signal.shape[1] / sampling_rate,
+            np.atleast_2d(signal).shape[1] / sampling_rate,
             unit='s',
         )
     elif isinstance(end, (int, float)):


### PR DESCRIPTION
Closes #152 

Add `pyarrow` as dependency as this is needed in `pandas` 3.0.0, see https://github.com/pandas-dev/pandas/issues/54466.

It also fixes an error in the `process_signal()` tests which did not account for returning always a signal of at least 2 dimensions when using `None` as process function. The behavior of this did not change, but the underlying test function (`pd.testing.assert_series_equal()`) is raising an error if the shapes to not match with `pandas>=2.2.0`