### PR TITLE
Depend on audeer>=1.18.0

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -502,7 +502,7 @@ class Feature:
                 but ``win_dur`` is not set
 
         """
-        root = audeer.safe_path(root)
+        root = audeer.path(root)
         if not os.path.exists(root):
             raise FileNotFoundError(
                 errno.ENOENT,

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -465,7 +465,7 @@ class Process:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        root = audeer.safe_path(root)
+        root = audeer.path(root)
         if not os.path.exists(root):
             raise FileNotFoundError(
                 errno.ENOENT,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -359,7 +359,7 @@ class Segment:
         .. _audformat: https://audeering.github.io/audformat/data-format.html
 
         """
-        root = audeer.safe_path(root)
+        root = audeer.path(root)
         if not os.path.exists(root):
             raise FileNotFoundError(
                 errno.ENOENT,

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -5,9 +5,8 @@ import typing
 import numpy as np
 import pandas as pd
 
-import audeer
 import audformat
-import audiofile as af
+import audiofile
 import audmath
 import audresample
 
@@ -143,8 +142,8 @@ def read_audio(
     else:
         duration = end.total_seconds() - offset
 
-    signal, sampling_rate = af.read(
-        audeer.safe_path(file),
+    signal, sampling_rate = audiofile.read(
+        file,
         always_2d=True,
         offset=offset,
         duration=duration,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,7 @@ classifiers = [
 ]
 requires-python = '>=3.8'
 dependencies = [
-    'audeer@git+https://github.com/audeering/audeer#egg=release-2.0.0',
-    # Should be changed to
-    #'audeer >=1.21.0',
+    'audeer >=1.18.0',
     'audformat >=1.0.1,<2.0.0',
     'audiofile >=1.3.0',
     'audmath >=1.3.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requires-python = '>=3.8'
 dependencies = [
     'audeer@git+https://github.com/audeering/audeer#egg=release-2.0.0',
     # Should be changed to
-    #'audeer >=1.18.0',
+    #'audeer >=1.21.0',
     'audformat >=1.0.1,<2.0.0',
     'audiofile >=1.3.0',
     'audmath >=1.3.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ classifiers = [
 ]
 requires-python = '>=3.8'
 dependencies = [
+    'audeer@git+https://github.com/audeering/audeer#egg=release-2.0.0',
+    # Should be changed to
+    #'audeer >=1.18.0',
     'audformat >=1.0.1,<2.0.0',
     'audiofile >=1.3.0',
     'audmath >=1.3.0',

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+audeer >=1.21.0
 audb
 audobject >=0.7.5
 pytest

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -1029,7 +1029,7 @@ def test_feature_with_segment(audio, starts, ends):
         files_abs = None
     else:
         files = [file] * len(audeer.to_list(starts))
-        files_abs = [audeer.path(root, file) for file in files]
+        files_abs = [os.path.join(root, file) for file in files]
     expected = audformat.segmented_index(files, starts, ends)
     expected_folder_index = audformat.segmented_index(files_abs, starts, ends)
     expected_signal_index = audinterface.utils.signal_index(starts, ends)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -724,7 +724,7 @@ def test_process_index_filewise_end_times(tmpdir):
     # if NaT is forbidden,
     # see https://github.com/audeering/audinterface/issues/113
 
-    db_root = audeer.mkdir(audeer.path(tmpdir, 'tmp'))
+    db_root = audeer.mkdir(tmpdir, 'tmp')
     sampling_rate = 8000
     duration = 2.5225
     signal = np.ones((1, int(duration * sampling_rate)))
@@ -1561,7 +1561,7 @@ def test_process_with_segment(audio, starts, ends):
         files_abs = None
     else:
         files = [file] * len(audeer.to_list(starts))
-        files_abs = [audeer.path(root, file) for file in files]
+        files_abs = [os.path.join(root, file) for file in files]
     expected = audformat.segmented_index(files, starts, ends)
     expected_folder_index = audformat.segmented_index(files_abs, starts, ends)
     expected_signal_index = audinterface.utils.signal_index(starts, ends)


### PR DESCRIPTION
This tests the code for `audeer>=2.0.0` and updates the code.
It turns out that there are no needed changes for `audeer>=2.0.0` and we can instead update to `audeer>=1.18.0` and `audeer>=1.21.0` for the tests.