### PR TITLE
Add per execution process_func_args argument

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -408,6 +408,7 @@ class Feature:
             start: Timestamp = None,
             end: Timestamp = None,
             root: str = None,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.DataFrame:
         r"""Extract features from an audio file.
 
@@ -420,6 +421,10 @@ class Feature:
                 If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             root: root folder to expand relative file path
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                :attr:`audinterface.Process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -433,6 +438,7 @@ class Feature:
             start=start,
             end=end,
             root=root,
+            process_func_args=process_func_args,
         )
         return self._series_to_frame(series)
 
@@ -443,6 +449,7 @@ class Feature:
             starts: Timestamps = None,
             ends: Timestamps = None,
             root: str = None,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.DataFrame:
         r"""Extract features for a list of files.
 
@@ -459,6 +466,10 @@ class Feature:
                 for further options.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                :attr:`audinterface.Process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -472,6 +483,7 @@ class Feature:
             starts=starts,
             ends=ends,
             root=root,
+            process_func_args=process_func_args,
         )
         return self._series_to_frame(series)
 
@@ -481,6 +493,7 @@ class Feature:
             *,
             filetype: str = 'wav',
             include_root: bool = True,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.DataFrame:
         r"""Extract features from files in a folder.
 
@@ -493,6 +506,10 @@ class Feature:
                 the file paths are absolute
                 in the index
                 of the returned result
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                :attr:`audinterface.Process.process_func_args`
 
         Raises:
             FileNotFoundError: if folder does not exist
@@ -515,7 +532,11 @@ class Feature:
             filetype=filetype,
             basenames=not include_root,
         )
-        return self.process_files(files, root=root)
+        return self.process_files(
+            files,
+            root=root,
+            process_func_args=process_func_args,
+        )
 
     def process_index(
             self,
@@ -524,6 +545,7 @@ class Feature:
             preserve_index: bool = False,
             root: str = None,
             cache_root: str = None,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.DataFrame:
         r"""Extract features from an index conform to audformat_.
 
@@ -547,6 +569,10 @@ class Feature:
                 otherwise always a segmented index is returned
             root: root folder to expand relative file paths
             cache_root: cache folder (see description)
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                :attr:`audinterface.Process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -569,6 +595,7 @@ class Feature:
             y = self.process.process_index(
                 index,
                 root=root,
+                process_func_args=process_func_args,
             )
             df = self._series_to_frame(y)
 
@@ -590,7 +617,8 @@ class Feature:
             file: str = None,
             start: Timestamp = None,
             end: Timestamp = None,
-    ) -> pd.DataFrame:
+            process_func_args: typing.Dict[str, typing.Any] = None,
+   ) -> pd.DataFrame:
         r"""Extract features for an audio signal.
 
         .. note:: If a ``file`` is given, the index of the returned frame
@@ -607,6 +635,10 @@ class Feature:
             end: end processing at this position.
                 If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                :attr:`audinterface.Process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -627,6 +659,7 @@ class Feature:
             file=file,
             start=start,
             end=end,
+            process_func_args=process_func_args,
         )
         return self._series_to_frame(series)
 
@@ -635,6 +668,7 @@ class Feature:
             signal: np.ndarray,
             sampling_rate: int,
             index: pd.MultiIndex,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.DataFrame:
         r"""Split a signal into segments and extract features for each segment.
 
@@ -645,6 +679,10 @@ class Feature:
                 named `start` and `end` that hold start and end
                 positions as :class:`pandas.Timedelta` objects.
                 See also :func:`audinterface.utils.signal_index`
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                :attr:`audinterface.Process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -658,6 +696,7 @@ class Feature:
             signal,
             sampling_rate,
             index,
+            process_func_args=process_func_args,
         )
         return self._series_to_frame(series)
 

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -424,6 +424,7 @@ class Feature:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Raises:
@@ -469,6 +470,7 @@ class Feature:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Raises:
@@ -509,6 +511,7 @@ class Feature:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Raises:
@@ -572,6 +575,7 @@ class Feature:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Raises:
@@ -638,6 +642,7 @@ class Feature:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Raises:
@@ -682,6 +687,7 @@ class Feature:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Raises:

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -425,7 +425,7 @@ class Feature:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Feature.process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -471,7 +471,7 @@ class Feature:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Feature.process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -512,7 +512,7 @@ class Feature:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Feature.process.process_func_args`
 
         Raises:
             FileNotFoundError: if folder does not exist
@@ -576,7 +576,7 @@ class Feature:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Feature.process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -643,7 +643,7 @@ class Feature:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Feature.process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match
@@ -688,7 +688,7 @@ class Feature:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Feature.process.process_func_args`
 
         Raises:
             RuntimeError: if sampling rates do not match

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -308,6 +308,7 @@ class Process:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Returns:
@@ -372,6 +373,7 @@ class Process:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Returns:
@@ -463,6 +465,7 @@ class Process:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Returns:
@@ -570,6 +573,7 @@ class Process:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Returns:
@@ -730,6 +734,7 @@ class Process:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Returns:
@@ -867,6 +872,7 @@ class Process:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Returns:

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -171,7 +171,8 @@ class Process:
         if win_dur is not None and hop_dur is None:
             hop_dur = utils.to_timedelta(win_dur, sampling_rate) / 2
 
-        self._process_func_signature = inspect.signature(process_func).parameters
+        signature = inspect.signature(process_func)
+        self._process_func_signature = signature.parameters
         r"""Arguments present in processing function."""
 
         self.channels = channels

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -159,6 +159,7 @@ class ProcessWithContext:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Returns:
@@ -272,6 +273,7 @@ class ProcessWithContext:
             process_func_args: (keyword) arguments passed on
                 to the processing function.
                 They will temporarily overwrite
+                the ones stored in
                 :attr:`audinterface.Process.process_func_args`
 
         Returns:

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -119,7 +119,8 @@ class ProcessWithContext:
                 'sampling_rate has to be provided for resample = True.'
             )
 
-        self._process_func_signature = inspect.signature(process_func).parameters
+        signature = inspect.signature(process_func)
+        self._process_func_signature = signature.parameters
         r"""Arguments present in processing function."""
 
         self.channels = channels

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -119,21 +119,8 @@ class ProcessWithContext:
                 'sampling_rate has to be provided for resample = True.'
             )
 
-        # figure out if special arguments
-        # to pass to the processing function
-        signature = inspect.signature(process_func)
-        process_func_args = process_func_args or {}
-        self._process_func_special_args = {
-            'idx': False,
-            'root': False,
-            'file': False,
-        }
-        for key in self._process_func_special_args:
-            if (
-                    key in signature.parameters
-                    and key not in process_func_args
-            ):
-                self._process_func_special_args[key] = True
+        self._process_func_signature = inspect.signature(process_func).parameters
+        r"""Arguments present in processing function."""
 
         self.channels = channels
         r"""Channel selection."""
@@ -144,7 +131,7 @@ class ProcessWithContext:
         self.process_func = process_func
         r"""Process function."""
 
-        self.process_func_args = process_func_args
+        self.process_func_args = process_func_args or {}
         r"""Additional keyword arguments to processing function."""
 
         self.resample = resample
@@ -161,12 +148,17 @@ class ProcessWithContext:
             index: pd.Index,
             *,
             root: str = None,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.Series:
         r"""Process from a segmented index conform to audformat_.
 
         Args:
             index: index with segment information
             root: root folder to expand relative file paths
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                :attr:`audinterface.Process.process_func_args`
 
         Returns:
             Series with processed segments conform to audformat_
@@ -212,6 +204,7 @@ class ProcessWithContext:
                     idx=idx,
                     root=root,
                     file=file,
+                    process_func_args=process_func_args,
                 )
 
                 ys.append(y)
@@ -230,7 +223,8 @@ class ProcessWithContext:
             idx: int = 0,
             root: str = None,
             file: str = None,
-    ) -> typing.Any:
+            process_func_args: typing.Dict[str, typing.Any] = None,
+   ) -> typing.Any:
 
         starts_i, ends_i = utils.segments_to_indices(
             signal,
@@ -245,6 +239,7 @@ class ProcessWithContext:
             idx=idx,
             root=root,
             file=file,
+            process_func_args=process_func_args,
         )
         if (
                 not isinstance(y, collections.abc.Iterable)
@@ -262,6 +257,7 @@ class ProcessWithContext:
             signal: np.ndarray,
             sampling_rate: int,
             index: pd.Index,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.Series:
         r"""Split a signal into segments and process each segment.
 
@@ -272,6 +268,10 @@ class ProcessWithContext:
                 named `start` and `end` that hold start and end
                 positions as :class:`pandas.Timedelta` objects.
                 See also :func:`audinterface.utils.signal_index`
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                :attr:`audinterface.Process.process_func_args`
 
         Returns:
             Series with processed segments conform to audformat_
@@ -295,6 +295,7 @@ class ProcessWithContext:
             signal,
             sampling_rate,
             index,
+            process_func_args=process_func_args,
         )
         y = pd.Series(y, index)
 
@@ -310,6 +311,7 @@ class ProcessWithContext:
         idx: int = 0,
         root: str = None,
         file: str = None,
+        process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> typing.Any:
         r"""Call processing function, possibly pass special args."""
         signal, sampling_rate = utils.preprocess_signal(
@@ -321,14 +323,19 @@ class ProcessWithContext:
             self.mixdown,
         )
 
+        process_func_args = process_func_args or self.process_func_args
         special_args = {}
         for key, value in [
             ('idx', idx),
             ('root', root),
             ('file', file),
         ]:
-            if self._process_func_special_args[key]:
+            if (
+                    key in self._process_func_signature
+                    and key not in process_func_args
+            ):
                 special_args[key] = value
+
 
         return self.process_func(
             signal,
@@ -336,7 +343,7 @@ class ProcessWithContext:
             starts,
             ends,
             **special_args,
-            **self.process_func_args,
+            **process_func_args,
         )
 
     def __call__(

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -160,7 +160,7 @@ class ProcessWithContext:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.ProcessWithContext.process_func_args`
 
         Returns:
             Series with processed segments conform to audformat_
@@ -274,7 +274,7 @@ class ProcessWithContext:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.ProcessWithContext.process_func_args`
 
         Returns:
             Series with processed segments conform to audformat_

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -239,6 +239,7 @@ class Segment:
             start: Timestamp = None,
             end: Timestamp = None,
             root: str = None,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.Index:
         r"""Segment the content of an audio file.
 
@@ -251,6 +252,11 @@ class Segment:
                 If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
             root: root folder to expand relative file path
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                the ones stored in
+                :attr:`audinterface.Process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -269,6 +275,7 @@ class Segment:
             start=start,
             end=end,
             root=root,
+            process_func_args=process_func_args,
         ).values[0]
         return audformat.segmented_index(
             files=[file] * len(index),
@@ -283,6 +290,7 @@ class Segment:
             starts: Timestamps = None,
             ends: Timestamps = None,
             root: str = None,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.Index:
         r"""Segment a list of files.
 
@@ -299,6 +307,11 @@ class Segment:
                 for further options.
                 If a scalar is given, it is applied to all files
             root: root folder to expand relative file paths
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                the ones stored in
+                :attr:`audinterface.Process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -315,6 +328,7 @@ class Segment:
             starts=starts,
             ends=ends,
             root=root,
+            process_func_args=process_func_args,
         )
         if len(y) == 0:
             return audformat.filewise_index()
@@ -335,6 +349,7 @@ class Segment:
             *,
             filetype: str = 'wav',
             include_root: bool = True,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.Index:
         r"""Segment files in a folder.
 
@@ -347,6 +362,11 @@ class Segment:
                 the file paths are absolute
                 in the index
                 of the returned result
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                the ones stored in
+                :attr:`audinterface.Process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -372,7 +392,11 @@ class Segment:
             filetype=filetype,
             basenames=not include_root,
         )
-        return self.process_files(files, root=root)
+        return self.process_files(
+            files,
+            root=root,
+            process_func_args=process_func_args,
+        )
 
     def process_index(
             self,
@@ -380,6 +404,7 @@ class Segment:
             *,
             root: str = None,
             cache_root: str = None,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.Index:
         r"""Segment files or segments from an index.
 
@@ -395,6 +420,11 @@ class Segment:
             index: index conform to audformat_
             root: root folder to expand relative file paths
             cache_root: cache folder (see description)
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                the ones stored in
+                :attr:`audinterface.Process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -417,6 +447,7 @@ class Segment:
             preserve_index=False,
             root=root,
             cache_root=cache_root,
+            process_func_args=process_func_args,
         )
 
         files = []
@@ -437,6 +468,7 @@ class Segment:
             file: str = None,
             start: Timestamp = None,
             end: Timestamp = None,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.Index:
         r"""Segment audio signal.
 
@@ -454,6 +486,11 @@ class Segment:
             end: end processing at this position.
                 If value is a float or integer it is treated as seconds.
                 See :func:`audinterface.utils.to_timedelta` for further options
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                the ones stored in
+                :attr:`audinterface.Process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -471,6 +508,7 @@ class Segment:
             file=file,
             start=start,
             end=end,
+            process_func_args=process_func_args,
         ).values[0]
         utils.assert_index(index)
         if start is not None:
@@ -501,6 +539,7 @@ class Segment:
             signal: np.ndarray,
             sampling_rate: int,
             index: pd.Index,
+            process_func_args: typing.Dict[str, typing.Any] = None,
     ) -> pd.Index:
         r"""Segment parts of a signal.
 
@@ -512,6 +551,11 @@ class Segment:
                 named `start` and `end` that hold start and end
                 positions as :class:`pandas.Timedelta` objects.
                 See also :func:`audinterface.utils.signal_index`
+            process_func_args: (keyword) arguments passed on
+                to the processing function.
+                They will temporarily overwrite
+                the ones stored in
+                :attr:`audinterface.Process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -543,7 +587,12 @@ class Segment:
             params = [
                 (
                     (signal, sampling_rate),
-                    {'file': file, 'start': start, 'end': end},
+                    {
+                        'file': file,
+                        'start': start,
+                        'end': end,
+                        'process_func_args': process_func_args,
+                    },
                 ) for file, start, end in index
             ]
 

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -256,7 +256,7 @@ class Segment:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Segment.process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -311,7 +311,7 @@ class Segment:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Segment.process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -366,7 +366,7 @@ class Segment:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Segment.process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -424,7 +424,7 @@ class Segment:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Segment.process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -490,7 +490,7 @@ class Segment:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Segment.process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_
@@ -555,7 +555,7 @@ class Segment:
                 to the processing function.
                 They will temporarily overwrite
                 the ones stored in
-                :attr:`audinterface.Process.process_func_args`
+                :attr:`audinterface.Segment.process.process_func_args`
 
         Returns:
             Segmented index conform to audformat_

--- a/tests/test_process_func_args.py
+++ b/tests/test_process_func_args.py
@@ -1,13 +1,11 @@
 import os
 
 import numpy as np
-import pandas as pd
 import pytest
 
 import audeer
 import audformat
 import audiofile
-import audobject
 
 import audinterface
 

--- a/tests/test_process_func_args.py
+++ b/tests/test_process_func_args.py
@@ -1,6 +1,7 @@
 import os
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import audeer
@@ -10,49 +11,175 @@ import audiofile
 import audinterface
 
 
+def addition(signal, sampling_rate, value=1):
+    return signal + value * signal
+
+
 def identity(signal, sampling_rate):
     return signal
 
 
-def addition(signal, sampling_rate, value=1):
-    return signal + value * signal
+def mean(signal, sampling_rate, offset=0):
+    return np.mean(signal + offset)
+
+
+def segment(signal, sampling_rate, offset=0):
+    return audinterface.utils.signal_index(
+        starts=0 + offset,
+        ends=1 + offset,
+    )
+
+
+def parse_output(output):
+    r"""Return output as array or index.
+
+    This removes the ``file`` level,
+    if the output is an index
+    as we cannot provide the file name
+    as expected output.
+
+    Args:
+        output: output of process method
+
+    Returns:
+        output as array or index with start and end levels
+
+    """
+    if isinstance(output, pd.MultiIndex):
+        output = audinterface.utils.signal_index(
+            output.get_level_values('start'),
+            output.get_level_values('end'),
+        )
+    else:
+        output = output.values[0]
+    return output
 
 
 @pytest.mark.parametrize('signal', [np.ones((1, 3))])
 @pytest.mark.parametrize('sampling_rate', [8000])
 @pytest.mark.parametrize(
-    'process_func, process_func_args, process_func_args_during_call, '
-    'expected_output',
+    'interface_object, interface_args, process_func, process_func_args, '
+    'process_func_args_during_call, expected_output',
     [
         (
+            audinterface.Process,
+            [],
             addition,
             None,
             None,
             2 * np.ones((1, 3)),
         ),
         (
+            audinterface.Process,
+            [],
             addition,
             {'value': 0},
             None,
             np.ones((1, 3)),
         ),
         (
+            audinterface.Process,
+            [],
             addition,
             None,
             {'value': 0},
             np.ones((1, 3)),
         ),
         (
+            audinterface.Process,
+            [],
             addition,
             {'value': 0},
             {'value': 2},
             3 * np.ones((1, 3)),
         ),
         (
+            audinterface.Process,
+            [],
             addition,
             {'value': 2},
             {'value': 0},
             np.ones((1, 3)),
+        ),
+        (
+            audinterface.Feature,
+            ['mean'],
+            mean,
+            None,
+            None,
+            1,
+        ),
+        (
+            audinterface.Feature,
+            ['mean'],
+            mean,
+            {'offset': 1},
+            None,
+            2,
+        ),
+        (
+            audinterface.Feature,
+            ['mean'],
+            mean,
+            None,
+            {'offset': 1},
+            2,
+        ),
+        (
+            audinterface.Feature,
+            ['mean'],
+            mean,
+            {'offset': 0},
+            {'offset': 2},
+            3,
+        ),
+        (
+            audinterface.Feature,
+            ['mean'],
+            mean,
+            {'offset': 2},
+            {'offset': 0},
+            1,
+        ),
+        (
+            audinterface.Segment,
+            [],
+            segment,
+            None,
+            None,
+            audinterface.utils.signal_index(0, 1),
+        ),
+        (
+            audinterface.Segment,
+            [],
+            segment,
+            {'offset': 1},
+            None,
+            audinterface.utils.signal_index(1, 2),
+        ),
+        (
+            audinterface.Segment,
+            [],
+            segment,
+            None,
+            {'offset': 1},
+            audinterface.utils.signal_index(1, 2),
+        ),
+        (
+            audinterface.Segment,
+            [],
+            segment,
+            {'offset': 0},
+            {'offset': 2},
+            audinterface.utils.signal_index(2, 3),
+        ),
+        (
+            audinterface.Segment,
+            [],
+            segment,
+            {'offset': 2},
+            {'offset': 0},
+            audinterface.utils.signal_index(0, 1),
         ),
     ],
 )
@@ -60,6 +187,8 @@ def test_process(
     tmpdir,
     signal,
     sampling_rate,
+    interface_object,
+    interface_args,
     process_func,
     process_func_args,
     process_func_args_during_call,
@@ -71,44 +200,51 @@ def test_process(
     file = os.path.join(folder, 'file.wav')
     audiofile.write(file, signal, sampling_rate, bit_depth=32)
 
-    process = audinterface.Process(
+    interface = interface_object(
+        *interface_args,
         process_func=process_func,
         process_func_args=process_func_args,
         verbose=False,
     )
 
     # signal
-    y = process.process_signal(
+    y = interface.process_signal(
         signal,
         sampling_rate,
         process_func_args=process_func_args_during_call,
     )
-    np.testing.assert_equal(y.values[0], expected_output)
+    print(y)
+    output = parse_output(y)
+    np.testing.assert_equal(output, expected_output)
 
     # file
-    y = process.process_file(
+    y = interface.process_file(
         file,
         process_func_args=process_func_args_during_call,
     )
-    np.testing.assert_equal(y.values[0], expected_output)
+    output = parse_output(y)
+    np.testing.assert_equal(output, expected_output)
 
     # files
-    y = process.process_files(
+    y = interface.process_files(
         [file],
         process_func_args=process_func_args_during_call,
     )
-    np.testing.assert_equal(y.values[0], expected_output)
+    output = parse_output(y)
+    np.testing.assert_equal(output, expected_output)
 
     # folder
-    y = process.process_folder(
+    y = interface.process_folder(
         folder,
         process_func_args=process_func_args_during_call,
     )
-    np.testing.assert_equal(y.values[0], expected_output)
+    output = parse_output(y)
+    np.testing.assert_equal(output, expected_output)
 
     # index
-    y = process.process_index(
+    y = interface.process_index(
         audformat.filewise_index([file]),
         process_func_args=process_func_args_during_call,
     )
-    np.testing.assert_equal(y.values[0], expected_output)
+    output = parse_output(y)
+    np.testing.assert_equal(output, expected_output)

--- a/tests/test_process_func_args.py
+++ b/tests/test_process_func_args.py
@@ -1,0 +1,116 @@
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import audeer
+import audformat
+import audiofile
+import audobject
+
+import audinterface
+
+
+def identity(signal, sampling_rate):
+    return signal
+
+
+def addition(signal, sampling_rate, value=1):
+    return signal + value * signal
+
+
+@pytest.mark.parametrize('signal', [np.ones((1, 3))])
+@pytest.mark.parametrize('sampling_rate', [8000])
+@pytest.mark.parametrize(
+    'process_func, process_func_args, process_func_args_during_call, '
+    'expected_output',
+    [
+        (
+            addition,
+            None,
+            None,
+            2 * np.ones((1, 3)),
+        ),
+        (
+            addition,
+            {'value': 0},
+            None,
+            np.ones((1, 3)),
+        ),
+        (
+            addition,
+            None,
+            {'value': 0},
+            np.ones((1, 3)),
+        ),
+        (
+            addition,
+            {'value': 0},
+            {'value': 2},
+            3 * np.ones((1, 3)),
+        ),
+        (
+            addition,
+            {'value': 2},
+            {'value': 0},
+            np.ones((1, 3)),
+        ),
+    ],
+)
+def test_process(
+    tmpdir,
+    signal,
+    sampling_rate,
+    process_func,
+    process_func_args,
+    process_func_args_during_call,
+    expected_output,
+):
+
+    # create test file
+    folder = audeer.mkdir(tmpdir, 'wav')
+    file = os.path.join(folder, 'file.wav')
+    audiofile.write(file, signal, sampling_rate, bit_depth=32)
+
+    process = audinterface.Process(
+        process_func=process_func,
+        process_func_args=process_func_args,
+        verbose=False,
+    )
+
+    # signal
+    y = process.process_signal(
+        signal,
+        sampling_rate,
+        process_func_args=process_func_args_during_call,
+    )
+    np.testing.assert_equal(y.values[0], expected_output)
+
+    # file
+    y = process.process_file(
+        file,
+        process_func_args=process_func_args_during_call,
+    )
+    np.testing.assert_equal(y.values[0], expected_output)
+
+    # files
+    y = process.process_files(
+        [file],
+        process_func_args=process_func_args_during_call,
+    )
+    np.testing.assert_equal(y.values[0], expected_output)
+
+    # folder
+    y = process.process_folder(
+        folder,
+        process_func_args=process_func_args_during_call,
+    )
+    np.testing.assert_equal(y.values[0], expected_output)
+
+    # index
+    y = process.process_index(
+        audformat.filewise_index([file]),
+        process_func_args=process_func_args_during_call,
+    )
+    np.testing.assert_equal(y.values[0], expected_output)


### PR DESCRIPTION
Closes #156 

This adds a `process_func_args` argument to all the processing methods, e.g. `audinterface.Process.process_index()`.
It can be used to overwrite the `process_func_args` argument used during instantiation of the interface.

Example:

```python
import audinterface
import numpy as np

def addition(signal, sampling_rate, value=1):
    return signal + value * signal

interface = audinterface.Process(
    process_func=addition,
    process_func_args={"value": 2},
)
signal = np.ones((1, 3))
sampling_rate = 8000
interface.process_signal(signal, sampling_rate, process_func_args={"value": 3})
```
returns
```
start   end                   
0 days  0 days 00:00:00.000375    [[4.0, 4.0, 4.0]]
dtype: object
```

It will not overwrite the content of the class attribute `interface.process_func_args`, which will always only store the global setting.

Example docstring:

![image](https://github.com/audeering/audinterface/assets/173624/736a6465-0678-4c08-b676-ab8e0cbe5c0d)
