### PR TITLE
DOC: avoid deprecation warnings

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -440,11 +440,11 @@ to select the appropriate f0 range.
         # extract mean f0 using a gender adapted range
         y = librosa.yin(
             signal,
-            fmin=f0_range[gender[idx]][0],
-            fmax=f0_range[gender[idx]][1],
+            fmin=f0_range[gender.iloc[idx]][0],
+            fmax=f0_range[gender.iloc[idx]][1],
             sr=sampling_rate,
         ).mean()
-        return y, gender[idx]
+        return y, gender.iloc[idx]
 
     interface = audinterface.Feature(
         ['f0', 'gender'],


### PR DESCRIPTION
Updates a usage example in the documentation to avoid `pandas` deprecation warnings.

![image](https://github.com/audeering/audinterface/assets/173624/407f879c-5e89-4421-955c-3f7f80c89675)
