### PR TITLE
Fix multiprocessing for Process, Feature, Segment

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -16,6 +16,30 @@ from audinterface.core.typing import Timestamps
 import audinterface.core.utils as utils
 
 
+def zeros(signal, sampling_rate, num_channels, num_features) -> np.ndarray:
+    r"""Default feature process function.
+
+    This function is used,
+    when ``Feature`` is instantiated
+    with ``process_func=None``.
+    It returns zeros for all channels and features.
+
+    Args:
+        signal: signal
+        sampling_rate: sampling rate in Hz
+        num_channels: number of audio channels
+        num_features: number of features
+
+    Returns:
+        zeros with size ``(num_channels, num_features)``
+
+    """
+    return np.zeros(
+        (num_channels, num_features),
+        dtype=object,
+    )
+
+
 class Feature:
     r"""Feature extraction interface.
 
@@ -260,13 +284,11 @@ class Feature:
         else:
             column_names = pd.Index(feature_names)
 
+        process_func_args = process_func_args or {}
         if process_func is None:
-
-            def process_func(signal, _):
-                return np.zeros(
-                    (num_channels, len(feature_names)),
-                    dtype=object,
-                )
+            process_func_args["num_channels"] = num_channels
+            process_func_args["num_features"] = len(feature_names)
+            process_func = zeros
 
         if win_dur is None and hop_dur is not None:
             raise ValueError("You have to specify 'win_dur' if 'hop_dur' is given.")
@@ -275,7 +297,6 @@ class Feature:
 
         # add 'win_dur' and 'hop_dur' to process_func_args
         # if expected by function but not yet set
-        process_func_args = process_func_args or {}
         signature = inspect.signature(process_func)
         if "win_dur" in signature.parameters and "win_dur" not in process_func_args:
             process_func_args["win_dur"] = win_dur

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -17,7 +17,7 @@ from audinterface.core.typing import Timestamp
 from audinterface.core.typing import Timestamps
 
 
-def identity(signal, sampling_rate):
+def identity(signal, sampling_rate) -> np.ndarray:
     r"""Default processing function.
 
     This function is used,

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -170,7 +170,7 @@ class Process:
             hop_dur = utils.to_timedelta(win_dur, sampling_rate) / 2
 
         signature = inspect.signature(process_func)
-        self._process_func_signature = signature.parameters
+        self._process_func_signature = dict(signature.parameters)
         r"""Arguments present in processing function."""
 
         self.channels = channels

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -18,7 +18,21 @@ from audinterface.core.typing import Timestamps
 
 
 def identity(signal, sampling_rate):
-    r"""Default processing function."""
+    r"""Default processing function.
+
+    This function is used,
+    when ``Process`` is instantiated
+    with ``process_func=None``.
+    It returns the given signal.
+
+    Args:
+        signal: signal
+        sampling_rate: sampling rate in Hz
+
+    Returns:
+        signal
+
+    """
     return signal
 
 

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -17,6 +17,11 @@ from audinterface.core.typing import Timestamp
 from audinterface.core.typing import Timestamps
 
 
+def identity(signal, sampling_rate):
+    r"""Default processing function."""
+    return signal
+
+
 class Process:
     r"""Processing interface.
 
@@ -156,11 +161,6 @@ class Process:
         if channels is not None:
             channels = audeer.to_list(channels)
 
-        if process_func is None:
-
-            def process_func(signal, _):
-                return signal
-
         if resample and sampling_rate is None:
             raise ValueError("sampling_rate has to be provided for resample = True.")
 
@@ -169,6 +169,7 @@ class Process:
         if win_dur is not None and hop_dur is None:
             hop_dur = utils.to_timedelta(win_dur, sampling_rate) / 2
 
+        process_func = process_func or identity
         signature = inspect.signature(process_func)
         self._process_func_signature = dict(signature.parameters)
         r"""Arguments present in processing function."""

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -12,6 +12,11 @@ import audformat
 from audinterface.core import utils
 
 
+def identity(signal, sampling_rate, starts, ends):
+    r"""Default processing function."""
+    return [signal[:, start:end] for start, end in zip(starts, ends)]
+
+
 class ProcessWithContext:
     r"""Alternate processing interface that provides signal context.
 
@@ -105,14 +110,10 @@ class ProcessWithContext:
         if channels is not None:
             channels = audeer.to_list(channels)
 
-        if process_func is None:
-
-            def process_func(signal, _, starts, ends):
-                return [signal[:, start:end] for start, end in zip(starts, ends)]
-
         if resample and sampling_rate is None:
             raise ValueError("sampling_rate has to be provided for resample = True.")
 
+        process_func = process_func or identity
         signature = inspect.signature(process_func)
         self._process_func_signature = signature.parameters
         r"""Arguments present in processing function."""

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -12,7 +12,7 @@ import audformat
 from audinterface.core import utils
 
 
-def identity(signal, sampling_rate, starts, ends):
+def identity(signal, sampling_rate, starts, ends) -> typing.List[np.ndarray]:
     r"""Default processing function.
 
     This function is used,

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -13,7 +13,23 @@ from audinterface.core import utils
 
 
 def identity(signal, sampling_rate, starts, ends):
-    r"""Default processing function."""
+    r"""Default processing function.
+
+    This function is used,
+    when ``ProcessWithContext`` is instantiated
+    with ``process_func=None``.
+    It returns all given segments.
+
+    Args:
+        signal: signal
+        sampling_rate: sampling rate in Hz
+        starts: start indices
+        ends: end indices
+
+    Returns:
+        list of segments
+
+    """
     return [signal[:, start:end] for start, end in zip(starts, ends)]
 
 

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -13,7 +13,7 @@ from audinterface.core.typing import Timestamp
 from audinterface.core.typing import Timestamps
 
 
-def signal_index(signal, sampling_rate, **kwargs):
+def signal_index(signal, sampling_rate, **kwargs) -> pd.MultiIndex:
     r"""Default segment process function.
 
     This function is used,
@@ -34,7 +34,13 @@ def signal_index(signal, sampling_rate, **kwargs):
     return utils.signal_index()
 
 
-def inverted_process_func(signal, sampling_rate, *, __process_func, **kwargs):
+def inverted_process_func(
+    signal,
+    sampling_rate,
+    *,
+    __process_func,
+    **kwargs,
+) -> pd.MultiIndex:
     r"""Inverted segment process function.
 
     This function is used,

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -19,6 +19,8 @@ def signal_index(signal, sampling_rate, **kwargs):
     This function is used,
     when ``Segment`` is instantiated
     with ``process_func=None``.
+    It returns an empty multi-index,
+    with levels ``start`` and ``end``.
 
     Args:
         signal: signal

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -330,7 +330,42 @@ def test_process_file(tmpdir, start, end, segment):
     np.testing.assert_array_equal(y, y_expected)
 
 
-def test_process_folder(tmpdir):
+@pytest.mark.parametrize(
+    "num_files, num_workers, multiprocessing",
+    [
+        (
+            3,
+            1,
+            False,
+        ),
+        (
+            3,
+            2,
+            False,
+        ),
+        (
+            3,
+            2,
+            True,
+        ),
+        (
+            3,
+            None,
+            False,
+        ),
+        (
+            3,
+            1,
+            False,
+        ),
+    ],
+)
+def test_process_folder(
+    tmpdir,
+    num_files,
+    num_workers,
+    multiprocessing,
+):
     index = audinterface.utils.signal_index(0, 1)
     feature_names = ["o1", "o2", "o3"]
     feature = audinterface.Feature(
@@ -343,7 +378,7 @@ def test_process_folder(tmpdir):
     )
 
     path = str(tmpdir.mkdir("wav"))
-    files = [f"file{n}.wav" for n in range(3)]
+    files = [f"file{n}.wav" for n in range(num_files)]
     files_abs = [os.path.join(path, file) for file in files]
     for file in files_abs:
         af.write(file, SIGNAL_2D, SAMPLING_RATE)

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -416,6 +416,62 @@ def test_process_folder(
     )
 
 
+@pytest.mark.parametrize(
+    "num_files, num_workers, multiprocessing",
+    [
+        (
+            3,
+            1,
+            False,
+        ),
+        (
+            3,
+            2,
+            False,
+        ),
+        (
+            3,
+            2,
+            True,
+        ),
+        (
+            3,
+            None,
+            False,
+        ),
+        (
+            3,
+            1,
+            False,
+        ),
+    ],
+)
+def test_process_folder_default_process_func(
+    tmpdir,
+    num_files,
+    num_workers,
+    multiprocessing,
+):
+    feature_names = ["o1", "o2", "o3"]
+    feature = audinterface.Feature(
+        feature_names,
+        process_func=None,
+        sampling_rate=None,
+        channels=range(NUM_CHANNELS),
+        resample=False,
+        verbose=False,
+    )
+
+    path = str(tmpdir.mkdir("wav"))
+    files = [f"file{n}.wav" for n in range(num_files)]
+    files_abs = [os.path.join(path, file) for file in files]
+    for file in files_abs:
+        af.write(file, SIGNAL_2D, SAMPLING_RATE)
+
+    y = feature.process_folder(path)
+    assert all(y.index.levels[0] == files_abs)
+
+
 def test_process_func_args():
     def process_func(s, sr, arg1, arg2):
         assert arg1 == "foo"

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -18,12 +18,16 @@ NUM_FEATURES = 3
 NUM_FRAMES = 5
 SIGNAL_1D = np.ones((1, SAMPLING_RATE))
 SIGNAL_2D = np.ones((NUM_CHANNELS, SAMPLING_RATE))
-SEGMENT = audinterface.Segment(
-    process_func=lambda x, sr: audinterface.utils.signal_index(
+
+
+def segment(signal, sampling_rate):
+    return audinterface.utils.signal_index(
         pd.to_timedelta(0),
-        pd.to_timedelta(x.shape[1] / sr, unit="s") / 2,
+        pd.to_timedelta(signal.shape[1] / sampling_rate, unit="s") / 2,
     )
-)
+
+
+SEGMENT = audinterface.Segment(process_func=segment)
 
 
 def feature_extractor(signal, _):
@@ -330,36 +334,9 @@ def test_process_file(tmpdir, start, end, segment):
     np.testing.assert_array_equal(y, y_expected)
 
 
-@pytest.mark.parametrize(
-    "num_files, num_workers, multiprocessing",
-    [
-        (
-            3,
-            1,
-            False,
-        ),
-        (
-            3,
-            2,
-            False,
-        ),
-        (
-            3,
-            2,
-            True,
-        ),
-        (
-            3,
-            None,
-            False,
-        ),
-        (
-            3,
-            1,
-            False,
-        ),
-    ],
-)
+@pytest.mark.parametrize("num_files", [3])
+@pytest.mark.parametrize("num_workers", [1, 2, None])
+@pytest.mark.parametrize("multiprocessing", [False, True])
 def test_process_folder(
     tmpdir,
     num_files,
@@ -416,36 +393,9 @@ def test_process_folder(
     )
 
 
-@pytest.mark.parametrize(
-    "num_files, num_workers, multiprocessing",
-    [
-        (
-            3,
-            1,
-            False,
-        ),
-        (
-            3,
-            2,
-            False,
-        ),
-        (
-            3,
-            2,
-            True,
-        ),
-        (
-            3,
-            None,
-            False,
-        ),
-        (
-            3,
-            1,
-            False,
-        ),
-    ],
-)
+@pytest.mark.parametrize("num_files", [3])
+@pytest.mark.parametrize("num_workers", [1, 2, None])
+@pytest.mark.parametrize("multiprocessing", [False, True])
 def test_process_folder_default_process_func(
     tmpdir,
     num_files,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -30,12 +30,14 @@ class SignalObject(audobject.Object):
         return np.max(signal)
 
 
-SEGMENT = audinterface.Segment(
-    process_func=lambda x, sr: audinterface.utils.signal_index(
+def segment(signal, sampling_rate):
+    return audinterface.utils.signal_index(
         pd.to_timedelta(0),
-        pd.to_timedelta(x.shape[1] / sr, unit="s") / 2,
+        pd.to_timedelta(signal.shape[1] / sampling_rate, unit="s") / 2,
     )
-)
+
+
+SEGMENT = audinterface.Segment(process_func=segment)
 
 
 def signal_modification(signal, sampling_rate, subtract=False):
@@ -508,41 +510,10 @@ def test_process_files(
     )
 
 
-@pytest.mark.parametrize(
-    "num_files, segment, num_workers, multiprocessing",
-    [
-        (
-            3,
-            None,
-            1,
-            False,
-        ),
-        (
-            3,
-            None,
-            2,
-            False,
-        ),
-        (
-            3,
-            None,
-            2,
-            True,
-        ),
-        (
-            3,
-            None,
-            None,
-            False,
-        ),
-        (
-            3,
-            SEGMENT,
-            1,
-            False,
-        ),
-    ],
-)
+@pytest.mark.parametrize("num_files", [3])
+@pytest.mark.parametrize("segment", [None, SEGMENT])
+@pytest.mark.parametrize("num_workers", [1, 2, None])
+@pytest.mark.parametrize("multiprocessing", [False, True])
 def test_process_folder(
     tmpdir,
     num_files,
@@ -595,24 +566,9 @@ def test_process_func_args():
     )
 
 
+@pytest.mark.parametrize("num_workers", [1, 2, None])
+@pytest.mark.parametrize("multiprocessing", [False, True])
 @pytest.mark.parametrize("preserve_index", [False, True])
-@pytest.mark.parametrize(
-    "num_workers, multiprocessing",
-    [
-        (
-            1,
-            False,
-        ),
-        (
-            2,
-            False,
-        ),
-        (
-            None,
-            False,
-        ),
-    ],
-)
 def test_process_index(tmpdir, num_workers, multiprocessing, preserve_index):
     cache_root = os.path.join(tmpdir, "cache")
 
@@ -1069,23 +1025,8 @@ def test_process_signal(
     pd.testing.assert_series_equal(x, y)
 
 
-@pytest.mark.parametrize(
-    "num_workers, multiprocessing",
-    [
-        (
-            1,
-            False,
-        ),
-        (
-            2,
-            False,
-        ),
-        (
-            None,
-            False,
-        ),
-    ],
-)
+@pytest.mark.parametrize("num_workers", [1, 2, None])
+@pytest.mark.parametrize("multiprocessing", [False, True])
 @pytest.mark.parametrize(
     "process_func, signal, sampling_rate, index",
     [

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -526,6 +526,12 @@ def test_process_files(
         (
             3,
             None,
+            2,
+            True,
+        ),
+        (
+            3,
+            None,
             None,
             False,
         ),

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -35,13 +35,11 @@ def test_process_func_args():
     )
 
 
-def test_process_index(tmpdir, num_workers, multiprocessing):
+def test_process_index(tmpdir):
     process = audinterface.ProcessWithContext(
         process_func=None,
         sampling_rate=None,
         resample=False,
-        num_workers=num_workers,
-        multiprocessing=multiprocessing,
         verbose=False,
     )
 

--- a/tests/test_process_with_context.py
+++ b/tests/test_process_with_context.py
@@ -35,11 +35,13 @@ def test_process_func_args():
     )
 
 
-def test_process_index(tmpdir):
+def test_process_index(tmpdir, num_workers, multiprocessing):
     process = audinterface.ProcessWithContext(
         process_func=None,
         sampling_rate=None,
         resample=False,
+        num_workers=num_workers,
+        multiprocessing=multiprocessing,
         verbose=False,
     )
 

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -82,27 +82,8 @@ def test_file(tmpdir):
     assert all(result.levels[2] == INDEX.levels[1] + pd.to_timedelta("1s"))
 
 
-@pytest.mark.parametrize(
-    "num_workers, multiprocessing",
-    [
-        (
-            1,
-            False,
-        ),
-        (
-            2,
-            False,
-        ),
-        (
-            2,
-            True,
-        ),
-        (
-            None,
-            False,
-        ),
-    ],
-)
+@pytest.mark.parametrize("num_workers", [1, 2, None])
+@pytest.mark.parametrize("multiprocessing", [False, True])
 def test_folder(tmpdir, num_workers, multiprocessing):
     segment = audinterface.Segment(
         process_func=predefined_index,
@@ -131,27 +112,8 @@ def test_folder(tmpdir, num_workers, multiprocessing):
     pd.testing.assert_index_equal(index, audformat.filewise_index())
 
 
-@pytest.mark.parametrize(
-    "num_workers, multiprocessing",
-    [
-        (
-            1,
-            False,
-        ),
-        (
-            2,
-            False,
-        ),
-        (
-            2,
-            True,
-        ),
-        (
-            None,
-            False,
-        ),
-    ],
-)
+@pytest.mark.parametrize("num_workers", [1, 2, None])
+@pytest.mark.parametrize("multiprocessing", [False, True])
 def test_folder_default_process_func(tmpdir, num_workers, multiprocessing):
     segment = audinterface.Segment(
         process_func=None,
@@ -169,29 +131,13 @@ def test_folder_default_process_func(tmpdir, num_workers, multiprocessing):
     assert len(result) == 0
 
 
-@pytest.mark.parametrize(
-    "num_workers, multiprocessing",
-    [
-        (
-            1,
-            False,
-        ),
-        (
-            2,
-            False,
-        ),
-        (
-            None,
-            False,
-        ),
-    ],
-)
-def test_index(tmpdir, num_workers, multiprocessing):
-    def process_func(x, sr):
-        dur = pd.to_timedelta(x.shape[-1] / sr, unit="s")
+@pytest.mark.parametrize("num_workers", [1, 2, None])
+def test_index(tmpdir, num_workers):
+    def process_func(signal, sampling_rate):
+        duration = pd.to_timedelta(signal.shape[-1] / sampling_rate, unit="s")
         return audinterface.utils.signal_index(
             "0.1s",
-            dur - pd.to_timedelta("0.1s"),
+            duration - pd.to_timedelta("0.1s"),
         )
 
     segment = audinterface.Segment(
@@ -199,7 +145,6 @@ def test_index(tmpdir, num_workers, multiprocessing):
         sampling_rate=None,
         resample=False,
         num_workers=num_workers,
-        multiprocessing=multiprocessing,
         verbose=False,
     )
 
@@ -288,7 +233,6 @@ def test_index(tmpdir, num_workers, multiprocessing):
         sampling_rate=None,
         resample=False,
         num_workers=num_workers,
-        multiprocessing=multiprocessing,
         verbose=False,
     )
 


### PR DESCRIPTION
Closes #165 

Ensure, that the `multiprocessing` argument of `audinterface.Process`, `audinterface.Feature`, `audinterface.Segment` does not result in an pickle related error, if set to `True`. Multiprocessing relies on [pickling all involved objects](https://laszukdawid.com/blog/2017/12/13/multiprocessing-in-python-all-about-pickling/) to communicate between processes.
The error was originally reported in https://github.com/audeering/opensmile-python/issues/104.

I added tests for `audinterface.Process`, `audinterface.Feature`, `audinterface.Segment`, to detect the error.
Most tests included already the `multiprocessing` argument, but it was always set to `False`.

The reason for the error consisted of two parts:

1. In https://github.com/audeering/audinterface/pull/157 we introduced
```python
signature = inspect.signature(process_func)
Process._process_func_signature = signature.parameters
```
The problem is that `Process._process_func_signature` cannot be pickled.
To fix this, I changed the code to 
```python
signature = inspect.signature(process_func)
Process._process_func_signature = dict(signature.parameters)
```
2. When `process_func=None` is selected, we provide default process functions. Before they were defined on the fly inside the object, which also results in objects that cannot be pickled. This is solved here, by defining the functions outside of the actual objects.

/cc @frankenjoe 