### PR TITLE
Remove deprecated unit argument from Feature

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -244,35 +244,7 @@ class Feature:
         num_workers: typing.Optional[int] = 1,
         multiprocessing: bool = False,
         verbose: bool = False,
-        **kwargs,
     ):
-        # ------
-        # Handle deprecated 'unit' keyword argument
-        def add_unit(dur, unit):
-            if unit == "samples":
-                return str(dur)
-            else:
-                return f"{dur}{unit}"
-
-        if "unit" in kwargs:
-            message = (
-                "'unit' argument is deprecated "
-                "and will be removed with version '1.2.0'."
-                "The unit can now directly specified "
-                "within the 'win_dur' and 'hop_dur' arguments."
-            )
-            warnings.warn(
-                message,
-                category=UserWarning,
-                stacklevel=2,
-            )
-            unit = kwargs.pop("unit")
-            if win_dur is not None:
-                win_dur = add_unit(win_dur, unit)
-            if hop_dur is not None:
-                hop_dur = add_unit(hop_dur, unit)
-        # ------
-
         if mixdown or isinstance(channels, int):
             num_channels = 1
         else:

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -2,7 +2,6 @@ import errno
 import inspect
 import os
 import typing
-import warnings
 
 import numpy as np
 import pandas as pd

--- a/tests/test_feature.py
+++ b/tests/test_feature.py
@@ -58,32 +58,6 @@ def mean_sliding_window_mono(signal, sampling_rate, win_dur, hop_dur):
     return frames.mean(axis=1, keepdims=False)
 
 
-def test_deprecated_unit_argument():
-    if audeer.LooseVersion(audinterface.__version__) < audeer.LooseVersion("1.2.0"):
-        with pytest.warns(UserWarning, match="is deprecated"):
-            interface = audinterface.Feature(
-                ["a"],
-                win_dur=1000,
-                unit="samples",
-                sampling_rate=16000,
-            )
-            assert interface.win_dur == "1000"
-            interface = audinterface.Feature(
-                ["a"],
-                win_dur=1000,
-                hop_dur=500,
-                unit="milliseconds",
-            )
-            assert interface.win_dur == "1000milliseconds"
-            assert interface.hop_dur == "500milliseconds"
-    else:
-        with pytest.raises(TypeError, match="unexpected keyword argument"):
-            audinterface.Feature(
-                ["a"],
-                unit="samples",
-            )
-
-
 def test_feature():
     # You have to specify sampling rate when win_dur is in samples
     with pytest.raises(ValueError):


### PR DESCRIPTION
Closes #164

Removes the handling of deprecated `unit` argum,ent in `audinterface.Feature` as it was marked to be removed in v1.2.0.