### PR TITLE
Require audmath>=1.4.1 to support numpy 2.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
 
     steps:
     - uses: actions/checkout@v3

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -111,7 +111,7 @@ class Process:
 
     Examples:
         >>> def mean(signal, sampling_rate):
-        ...     return signal.mean()
+        ...     return float(signal.mean())
         >>> interface = Process(process_func=mean)
         >>> signal = np.array([1.0, 2.0, 3.0])
         >>> interface(signal, sampling_rate=3)
@@ -133,11 +133,11 @@ class Process:
         >>> interface.process_index(index, root=db.root)
         file             start   end
         wav/03a01Fa.wav  0 days  0 days 00:00:01.898250    -0.000311
-        dtype: float32
+        dtype: float64
         >>> interface.process_index(index, root=db.root, preserve_index=True)
         file
         wav/03a01Fa.wav  -0.000311
-        dtype: float32
+        dtype: float64
         >>> # Apply interface with a sliding window
         >>> interface = Process(
         ...     process_func=mean,
@@ -148,7 +148,7 @@ class Process:
         file             start                   end
         wav/03a01Fa.wav  0 days 00:00:00         0 days 00:00:01          -0.000329
                          0 days 00:00:00.500000  0 days 00:00:01.500000   -0.000285
-        dtype: float32
+        dtype: float64
 
     """  # noqa: E501
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ auditok
 ipykernel
 jupyter-sphinx
 librosa
+numpy <2.0.0  # https://github.com/dofuuz/python-soxr/issues/28
 pyarrow
 sphinx
 sphinx-apipages >=0.1.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,8 +4,8 @@ auditok
 ipykernel
 jupyter-sphinx
 librosa
-numpy <2.0.0  # https://github.com/dofuuz/python-soxr/issues/28
 pyarrow
+soxr >=0.4.0b1  # for numpy 2, https://github.com/dofuuz/python-soxr/issues/28
 sphinx
 sphinx-apipages >=0.1.2
 sphinx-audeering-theme >=1.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,12 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.8'
+requires-python = '>=3.9'
 dependencies = [
     'audeer >=1.18.0',
     'audformat >=1.0.1,<2.0.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     'audeer >=1.18.0',
     'audformat >=1.0.1,<2.0.0',
     'audiofile >=1.3.0',
-    'audmath >=1.3.0',
+    'audmath >=1.4.1',
     'audresample >=1.1.0,<2.0.0',
 ]
 # Get version dynamically from git


### PR DESCRIPTION
This requires the latest version of `audmath` to ensure, that `audinterface` also works with `numpy` 2.0.

We also have to require `numpy<2.0.0` when building the docs as we use `librosa` in an example, which fails due to https://github.com/dofuuz/python-soxr/issues/28.

We cannot easily test Python 3.8 as `audb` caches created with `numpy` 2 cannot be read with older versions of `numpy`. As Python 3.8 reaches anyway its end of life, I decided to remove already support for Python 3.8, instead of adding workarounds for the tests.