### PR TITLE
TST: use sybil for doctests

### DIFF
--- a/audinterface/conftest.py
+++ b/audinterface/conftest.py
@@ -1,0 +1,10 @@
+from doctest import NORMALIZE_WHITESPACE
+
+from sybil import Sybil
+from sybil.parsers.rest import DocTestParser
+
+
+pytest_collect_file = Sybil(
+    parsers=[DocTestParser(optionflags=NORMALIZE_WHITESPACE)],
+    patterns=["*.py"],
+).pytest()

--- a/audinterface/conftest.py
+++ b/audinterface/conftest.py
@@ -1,3 +1,4 @@
+from doctest import ELLIPSIS
 from doctest import NORMALIZE_WHITESPACE
 
 from sybil import Sybil
@@ -5,6 +6,6 @@ from sybil.parsers.rest import DocTestParser
 
 
 pytest_collect_file = Sybil(
-    parsers=[DocTestParser(optionflags=NORMALIZE_WHITESPACE)],
+    parsers=[DocTestParser(optionflags=NORMALIZE_WHITESPACE + ELLIPSIS)],
     patterns=["*.py"],
 ).pytest()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosectionlabel",
+    "sphinx.ext.doctest",
     "sphinx_copybutton",  # for "copy to clipboard" buttons
     "sphinx_apipages",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,7 +35,6 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosectionlabel",
-    "sphinx.ext.doctest",
     "sphinx_copybutton",  # for "copy to clipboard" buttons
     "sphinx_apipages",
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,6 @@ exclude_patterns = [
 ]
 pygments_style = None
 extensions = [
-    "jupyter_sphinx",
     "sphinx.ext.napoleon",  # support for Google-style docstrings
     "sphinx_autodoc_typehints",
     "sphinx.ext.viewcode",

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,0 +1,9 @@
+from sybil import Sybil
+from sybil.parsers.rest import DocTestParser
+from sybil.parsers.rest import PythonCodeBlockParser
+
+
+pytest_collect_file = Sybil(
+    parsers=[DocTestParser(), PythonCodeBlockParser()],
+    patterns=["*.rst"],
+).pytest()

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,9 +1,14 @@
+from doctest import NORMALIZE_WHITESPACE
+
 from sybil import Sybil
 from sybil.parsers.rest import DocTestParser
 from sybil.parsers.rest import PythonCodeBlockParser
 
 
 pytest_collect_file = Sybil(
-    parsers=[DocTestParser(), PythonCodeBlockParser()],
+    parsers=[
+        DocTestParser(optionflags=NORMALIZE_WHITESPACE),
+        PythonCodeBlockParser(),
+    ],
     patterns=["*.rst"],
 ).pytest()

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,14 +1,29 @@
+from doctest import ELLIPSIS
 from doctest import NORMALIZE_WHITESPACE
+import os
 
+import pytest
 from sybil import Sybil
 from sybil.parsers.rest import DocTestParser
 from sybil.parsers.rest import PythonCodeBlockParser
 
 
+@pytest.fixture(scope="module")
+def execute_in_tmpdir(tmpdir_factory):
+    path = tmpdir_factory.mktemp("doctest")
+    cwd = os.getcwd()
+    try:
+        os.chdir(path)
+        yield path
+    finally:
+        os.chdir(cwd)
+
+
 pytest_collect_file = Sybil(
     parsers=[
-        DocTestParser(optionflags=NORMALIZE_WHITESPACE),
+        DocTestParser(optionflags=NORMALIZE_WHITESPACE + ELLIPSIS),
         PythonCodeBlockParser(),
     ],
     patterns=["*.rst"],
+    fixtures=["execute_in_tmpdir"],
 ).pytest()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,11 +1,5 @@
 audb
 audeer
-auditok
-ipykernel
-jupyter-sphinx
-librosa
-pyarrow
-soxr >=0.4.0b1  # for numpy 2, https://github.com/dofuuz/python-soxr/issues/28
 sphinx
 sphinx-apipages >=0.1.2
 sphinx-audeering-theme >=1.2.1

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,10 +1,3 @@
-.. Specify version for storing and loading objects to YAML
-
-   invisible-code-block: python
-
-    >>> __version__ = "1.0.0"
-
-
 Usage
 =====
 
@@ -43,10 +36,11 @@ and an index.
         "emodb",
         version="1.3.0",
         media=media,
+        full_path=False,
         verbose=False,
     )
     files = list(db.files)
-    folder = os.path.dirname(files[0])
+    folder = os.path.join(db.root, os.path.dirname(files[0]))
     index = db["emotion"].index
 
 
@@ -73,58 +67,43 @@ apply the algorithm
 and all return the same result
 as a :class:`pandas.Series`.
 
-.. doctest::
+>>> interface.process_files(files, root=db.root)
+file             start   end
+wav/03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
+wav/03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040703
+wav/16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
+dtype: float32
 
-    >>> interface.process_files(files)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    file             start   end
-    .../03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
-    .../03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040704
-    .../16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
-    dtype: float64
+>>> interface.process_folder(folder, include_root=False)
+file             start   end
+03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
+03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040703
+16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
+dtype: float32
 
-.. doctest::
-
-    >>> interface.process_folder(folder)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    file             start   end
-    .../03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
-    .../03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040704
-    .../16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
-    dtype: float64
-
-.. doctest::
-
-    >>> interface.process_index(index)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
-    file             start   end
-    .../03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
-    .../03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040704
-    .../16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
-    dtype: float64
+>>> interface.process_index(index, root=db.root)
+file             start   end
+wav/03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
+wav/03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040703
+wav/16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
+dtype: float32
 
 To calculate RMS with a sliding window,
 we create a new interface
 and set a window and hop duration.
 
-.. testcode::
-
-    interface = audinterface.Process(
-        process_func=rms,
-        win_dur=1.0,
-        hop_dur=0.5,
-    )
-    interface.process_files(files)
-
-.. testoutput::
-
-    file             start                   end
-    .../03a01Fa.wav  0 days 00:00:00         0 days 00:00:01          -20.165248
-                     0 days 00:00:00.500000  0 days 00:00:01.500000   -23.472970
-    .../03a01Nc.wav  0 days 00:00:00         0 days 00:00:01          -16.386614
-                     0 days 00:00:00.500000  0 days 00:00:01.500000   -19.502597
-    .../16b10Wb.wav  0 days 00:00:00         0 days 00:00:01          -21.733990
-                     0 days 00:00:00.500000  0 days 00:00:01.500000   -20.233054
-                     0 days 00:00:01         0 days 00:00:02          -18.856522
-                     0 days 00:00:01.500000  0 days 00:00:02.500000   -20.403574
-    dtype: float64
+>>> interface = audinterface.Process(process_func=rms, win_dur=1.0, hop_dur=0.5)
+>>> interface.process_files(files, root=db.root)
+file             start                   end
+wav/03a01Fa.wav  0 days 00:00:00         0 days 00:00:01          -20.165249
+                 0 days 00:00:00.500000  0 days 00:00:01.500000   -23.472969
+wav/03a01Nc.wav  0 days 00:00:00         0 days 00:00:01          -16.386614
+                 0 days 00:00:00.500000  0 days 00:00:01.500000   -19.502598
+wav/16b10Wb.wav  0 days 00:00:00         0 days 00:00:01          -21.733990
+                 0 days 00:00:00.500000  0 days 00:00:01.500000   -20.233055
+                 0 days 00:00:01         0 days 00:00:02          -18.856522
+                 0 days 00:00:01.500000  0 days 00:00:02.500000   -20.403574
+dtype: float32
 
 
 Feature interface
@@ -135,7 +114,7 @@ it is recommended to use :class:`audinterface.Feature`,
 which returns a :class:`pandas.DataFrame`
 and assigns names to the dimensions/features.
 
-.. testcode::
+.. code-block:: python
 
     def features(signal, sampling_rate):
         return [signal.mean(), signal.std()]
@@ -145,12 +124,12 @@ and assigns names to the dimensions/features.
         process_func=features,
     )
 
-    df = interface.process_index(index)
-
-.. doctest::
-
-    >>> df
-    bla
+>>> interface.process_index(index, root=db.root)
+                                                      mean       std
+file            start  end
+wav/03a01Fa.wav 0 days 0 days 00:00:01.898250    -0.000311  0.082317
+wav/03a01Nc.wav 0 days 0 days 00:00:01.611250    -0.000312  0.125304
+wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999 -0.000464  0.095558
 
 To calculate features with a sliding window,
 we create a new interface
@@ -160,7 +139,7 @@ By setting
 the windowing is automatically handled
 and single frames are passed on to the processing function.
 
-.. testcode::
+.. code-block:: python
 
     interface = audinterface.Feature(
         ["mean", "std"],
@@ -169,12 +148,19 @@ and single frames are passed on to the processing function.
         win_dur=1.0,
         hop_dur=0.5,
     )
-    df = interface.process_files(files)
 
-.. doctest::
+>>> interface.process_files(files, root=db.root)
+                                                                   mean       std
+file            start                  end
+wav/03a01Fa.wav 0 days 00:00:00        0 days 00:00:01        -0.000329  0.098115
+                0 days 00:00:00.500000 0 days 00:00:01.500000 -0.000285  0.067042
+wav/03a01Nc.wav 0 days 00:00:00        0 days 00:00:01         0.000039  0.151590
+                0 days 00:00:00.500000 0 days 00:00:01.500000 -0.000412  0.105893
+wav/16b10Wb.wav 0 days 00:00:00        0 days 00:00:01        -0.000455  0.081902
+                0 days 00:00:00.500000 0 days 00:00:01.500000 -0.000461  0.097351
+                0 days 00:00:01        0 days 00:00:02        -0.000469  0.114070
+                0 days 00:00:01.500000 0 days 00:00:02.500000 -0.000447  0.095459
 
-    >>> df
-    bla
 
 Feature interface for multi-channel input
 -----------------------------------------
@@ -186,12 +172,12 @@ We can prove this
 by running the previous interface
 on the following multi-channel signal.
 
-.. testcode::
+.. code-block:: python
 
     import audiofile
 
     signal, sampling_rate = audiofile.read(
-        files[0],
+        os.path.join(db.root, files[0]),
         always_2d=True,
     )
     signal_multi_channel = np.concatenate(
@@ -203,22 +189,13 @@ on the following multi-channel signal.
         ],
     )
 
-.. doctest::
-
-    >>> signal_multi_channel.shape
-    (4, 30372)
-
-.. testcode::
-
-    df = interface.process_signal(
-        signal_multi_channel,
-        sampling_rate,
-    )
-
-.. doctest::
-
-    >>> df
-    bla
+>>> signal_multi_channel.shape
+(4, 30372)
+>>> interface.process_signal(signal_multi_channel, sampling_rate)
+                                                   mean       std
+start                  end                                       
+0 days 00:00:00        0 days 00:00:01        -0.000329  0.098115
+0 days 00:00:00.500000 0 days 00:00:01.500000 -0.000285  0.067042
 
 To process the second and fourth channel,
 we create a new interface
@@ -234,7 +211,7 @@ the processing function must
 return an array with the correct
 number of channels (here 2).
 
-.. code-block::
+.. code-block:: python
 
     interface_multi_channel = audinterface.Feature(
         ["mean", "std"],
@@ -246,23 +223,23 @@ number of channels (here 2).
         channels=[1, 3],
     )
 
-    df = interface_multi_channel.process_signal(
-        signal_multi_channel,
-        sampling_rate,
-    )
+    df = interface_multi_channel.process_signal(signal_multi_channel, sampling_rate)
 
-.. doctest::
-
-    >>> df
-    bla
+>>> df
+                                                 1              3          
+                                              mean  std      mean       std
+start                  end                                                 
+0 days 00:00:00        0 days 00:00:01         0.0  0.0  0.499671  0.098115
+0 days 00:00:00.500000 0 days 00:00:01.500000  0.0  0.0  0.499715  0.067042
 
 We can access the features of a specific
 channel by its index.
 
-.. doctest::
-
-    >>> df[3]
-    bla
+>>> df[3]
+                                                   mean       std
+start                  end                                       
+0 days 00:00:00        0 days 00:00:01         0.499671  0.098115
+0 days 00:00:00.500000 0 days 00:00:01.500000  0.499715  0.067042
 
 
 Feature interface for external function
@@ -284,7 +261,7 @@ and returning the values in the correct shape,
 namely ``(num_channels, num_features, num_frames)``,
 whereas the first dimension is optionally.
 
-.. testcode::
+.. code-block:: python
 
     import librosa
 
@@ -309,12 +286,23 @@ whereas the first dimension is optionally.
         win_dur=0.02,
         hop_dur=0.01,
     )
-    df = interface.process_index(index)
 
-.. doctest::
-
-    >>> df
-    bla
+>>> interface.process_index(index, root=db.root)
+                                                                   mfcc-0  ...    mfcc-12
+file            start                  end                                 ...            
+wav/03a01Fa.wav 0 days 00:00:00        0 days 00:00:00.020000 -611.993286  ...   1.151396
+                0 days 00:00:00.010000 0 days 00:00:00.030000 -668.175842  ...  14.068543
+                0 days 00:00:00.020000 0 days 00:00:00.040000 -664.612793  ...   7.949757
+                0 days 00:00:00.030000 0 days 00:00:00.050000 -667.714722  ...  12.957479
+                0 days 00:00:00.040000 0 days 00:00:00.060000 -669.367432  ...   4.396849
+...                                                                   ...  ...        ...
+wav/16b10Wb.wav 0 days 00:00:02.480000 0 days 00:00:02.500000 -664.673584  ...   1.863654
+                0 days 00:00:02.490000 0 days 00:00:02.510000 -658.958069  ...   9.345045
+                0 days 00:00:02.500000 0 days 00:00:02.520000 -644.156494  ...   7.411011
+                0 days 00:00:02.510000 0 days 00:00:02.530000 -618.545898  ...  17.645359
+                0 days 00:00:02.520000 0 days 00:00:02.540000 -666.805237  ...   3.711080
+<BLANKLINE>
+[605 rows x 13 columns]
 
 
 Serializable feature interface
@@ -331,7 +319,7 @@ we create a class that inherits
 from :class:`audinterface.Feature`
 and :class:`audobject.Object`.
 
-.. testcode::
+.. code-block:: python
 
     import audobject
 
@@ -347,27 +335,33 @@ and :class:`audobject.Object`.
             return [signal.mean(), signal.std()]
 
     fex = MeanStd()
-    df = fex.process_index(index)
 
-.. doctest::
-
-    >>> df
-    bla
+>>> fex.process_index(index, root=db.root)
+                                                      mean       std
+file            start  end                                          
+wav/03a01Fa.wav 0 days 0 days 00:00:01.898250    -0.000311  0.082317
+wav/03a01Nc.wav 0 days 0 days 00:00:01.611250    -0.000312  0.125304
+wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999 -0.000464  0.095558
 
 The advantage of the feature extraction object is
 that we can save it to a YAML file
 and re-instantiate it from there.
 
-.. testcode::
+.. Specify version for storing and loading objects to YAML
+.. invisible-code-block: python
 
-    fex.to_yaml("mean-std.yaml")
-    fex2 = audobject.from_yaml("mean-std.yaml")
-    df = fex2.process_index(index)
+    __builtins__["__version__"] = "1.0.0"
+    __builtins__["MeanStd"] = MeanStd
 
-.. doctest::
 
-    >>> df
-    bla
+>>> fex.to_yaml("mean-std.yaml")
+>>> fex2 = audobject.from_yaml("mean-std.yaml")
+>>> fex2.process_index(index, root=db.root)
+                                                      mean       std
+file            start  end                                          
+wav/03a01Fa.wav 0 days 0 days 00:00:01.898250    -0.000311  0.082317
+wav/03a01Nc.wav 0 days 0 days 00:00:01.611250    -0.000312  0.125304
+wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999 -0.000464  0.095558
 
 
 Segmentation interface
@@ -379,9 +373,10 @@ which returns a segmented index conform to audformat_.
 An example for such a processing function
 would be a voice activity detection algorithm.
 
-.. testcode::
+.. code-block:: python
 
     import auditok
+    import pandas as pd
 
     def segments(signal, sampling_rate):
 
@@ -411,12 +406,11 @@ would be a voice activity detection algorithm.
         return index
 
     interface = audinterface.Segment(process_func=segments)
-    idx = interface.process_file(files[0])
 
-.. doctest::
-
-    >>> idx
-    bla
+>>> interface.process_file(files[0], root=db.root)
+MultiIndex([('wav/03a01Fa.wav', '0 days 00:00:00.150000', ...),
+            ('wav/03a01Fa.wav', '0 days 00:00:00.900000', ...)],
+           names=['file', 'start', 'end'])
 
 Sometimes,
 it is required that a table
@@ -434,15 +428,21 @@ is performed on an already labelled dataset
 in order to do data augmentation
 or teacher-student training.
 
-.. jupyter-execute::
-
-    table = pd.DataFrame({"label": [n * 2 for n in range(len(index))]}, index=index)
-    table
-    
-.. jupyter-execute::
-
-    table_segmented = interface.process_table(table)
-    table_segmented
+>>> table = pd.DataFrame({"label": [n * 2 for n in range(len(index))]}, index=index)
+>>> table
+                 label
+file                  
+wav/03a01Fa.wav      0
+wav/03a01Nc.wav      2
+wav/16b10Wb.wav      4
+>>> interface.process_table(table, root=db.root)
+                                                               label
+file            start                  end                          
+wav/03a01Fa.wav 0 days 00:00:00.150000 0 days 00:00:00.700000      0
+                0 days 00:00:00.900000 0 days 00:00:01.600000      0
+wav/03a01Nc.wav 0 days 00:00:00.100000 0 days 00:00:01.350000      2
+wav/16b10Wb.wav 0 days 00:00:00.300000 0 days 00:00:01             4
+                0 days 00:00:01.050000 0 days 00:00:02.500000      4
 
 
 Special processing function arguments
@@ -466,17 +466,19 @@ The following processing function
 returns the values of
 ``"idx"`` and ``"file"``.
 
-.. testcode::
+.. code-block:: python
 
     def special_args(signal, sampling_rate, idx, file):
         return idx, os.path.basename(file)
 
     interface = audinterface.Process(process_func=special_args)
-    y = interface.process_files(files)
 
-.. doctest::
-
-    >>> y
+>>> interface.process_files(files, root=db.root)
+file             start   end                      
+wav/03a01Fa.wav  0 days  0 days 00:00:01.898250       (0, 03a01Fa.wav)
+wav/03a01Nc.wav  0 days  0 days 00:00:01.611250       (1, 03a01Nc.wav)
+wav/16b10Wb.wav  0 days  0 days 00:00:02.522499999    (2, 16b10Wb.wav)
+dtype: object
 
 For instance,
 we can pass a list with gender labels
@@ -484,7 +486,7 @@ to the processing function
 and use the running index
 to select the appropriate f0 range.
 
-.. testcode::
+.. code-block:: python
 
     gender = db["files"]["speaker"].get(map="gender")  # gender per file
     f0_range = {
@@ -510,12 +512,13 @@ to select the appropriate f0 range.
             "f0_range": f0_range,
         },
     )
-    df = interface.process_index(gender.index)
 
-.. doctest::
-
-    >>> df
-    bla
+>>> interface.process_index(gender.index, root=db.root)
+                                                                  f0  gender
+file            start  end                                                  
+wav/03a01Fa.wav 0 days 0 days 00:00:01.898250      128.8100011977164    male
+wav/03a01Nc.wav 0 days 0 days 00:00:01.611250     111.63351213181389    male
+wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999  229.09341877352415  female
 
 
 .. _audformat: https://audeering.github.io/audformat/

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,3 +1,10 @@
+.. Limit precision of pandas output for doctests
+.. invisible-code-block: python
+
+    import pandas as pd
+    pd.set_option("display.precision", 4)
+
+
 Usage
 =====
 
@@ -69,23 +76,23 @@ as a :class:`pandas.Series`.
 
 >>> interface.process_files(files, root=db.root)
 file             start   end
-wav/03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
-wav/03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040703
-wav/16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
+wav/03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.6901
+wav/03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.0407
+wav/16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.3945
 dtype: float32
 
 >>> interface.process_folder(folder, include_root=False)
 file             start   end
-03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
-03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040703
-16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
+03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.6901
+03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.0407
+16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.3945
 dtype: float32
 
 >>> interface.process_index(index, root=db.root)
 file             start   end
-wav/03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
-wav/03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040703
-wav/16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
+wav/03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.6901
+wav/03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.0407
+wav/16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.3945
 dtype: float32
 
 To calculate RMS with a sliding window,
@@ -95,14 +102,14 @@ and set a window and hop duration.
 >>> interface = audinterface.Process(process_func=rms, win_dur=1.0, hop_dur=0.5)
 >>> interface.process_files(files, root=db.root)
 file             start                   end
-wav/03a01Fa.wav  0 days 00:00:00         0 days 00:00:01          -20.165249
-                 0 days 00:00:00.500000  0 days 00:00:01.500000   -23.472969
-wav/03a01Nc.wav  0 days 00:00:00         0 days 00:00:01          -16.386614
-                 0 days 00:00:00.500000  0 days 00:00:01.500000   -19.502598
-wav/16b10Wb.wav  0 days 00:00:00         0 days 00:00:01          -21.733990
-                 0 days 00:00:00.500000  0 days 00:00:01.500000   -20.233055
-                 0 days 00:00:01         0 days 00:00:02          -18.856522
-                 0 days 00:00:01.500000  0 days 00:00:02.500000   -20.403574
+wav/03a01Fa.wav  0 days 00:00:00         0 days 00:00:01          -20.1652
+                 0 days 00:00:00.500000  0 days 00:00:01.500000   -23.4730
+wav/03a01Nc.wav  0 days 00:00:00         0 days 00:00:01          -16.3866
+                 0 days 00:00:00.500000  0 days 00:00:01.500000   -19.5026
+wav/16b10Wb.wav  0 days 00:00:00         0 days 00:00:01          -21.7340
+                 0 days 00:00:00.500000  0 days 00:00:01.500000   -20.2331
+                 0 days 00:00:01         0 days 00:00:02          -18.8565
+                 0 days 00:00:01.500000  0 days 00:00:02.500000   -20.4036
 dtype: float32
 
 
@@ -125,11 +132,11 @@ and assigns names to the dimensions/features.
     )
 
 >>> interface.process_index(index, root=db.root)
-                                                      mean       std
+                                                    mean     std
 file            start  end
-wav/03a01Fa.wav 0 days 0 days 00:00:01.898250    -0.000311  0.082317
-wav/03a01Nc.wav 0 days 0 days 00:00:01.611250    -0.000312  0.125304
-wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999 -0.000464  0.095558
+wav/03a01Fa.wav 0 days 0 days 00:00:01.898250    -0.0003  0.0823
+wav/03a01Nc.wav 0 days 0 days 00:00:01.611250    -0.0003  0.1253
+wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999 -0.0005  0.0956
 
 To calculate features with a sliding window,
 we create a new interface
@@ -150,16 +157,16 @@ and single frames are passed on to the processing function.
     )
 
 >>> interface.process_files(files, root=db.root)
-                                                                   mean       std
-file            start                  end
-wav/03a01Fa.wav 0 days 00:00:00        0 days 00:00:01        -0.000329  0.098115
-                0 days 00:00:00.500000 0 days 00:00:01.500000 -0.000285  0.067042
-wav/03a01Nc.wav 0 days 00:00:00        0 days 00:00:01         0.000039  0.151590
-                0 days 00:00:00.500000 0 days 00:00:01.500000 -0.000412  0.105893
-wav/16b10Wb.wav 0 days 00:00:00        0 days 00:00:01        -0.000455  0.081902
-                0 days 00:00:00.500000 0 days 00:00:01.500000 -0.000461  0.097351
-                0 days 00:00:01        0 days 00:00:02        -0.000469  0.114070
-                0 days 00:00:01.500000 0 days 00:00:02.500000 -0.000447  0.095459
+                                                                     mean     std
+file            start                  end                                       
+wav/03a01Fa.wav 0 days 00:00:00        0 days 00:00:01        -3.2866e-04  0.0981
+                0 days 00:00:00.500000 0 days 00:00:01.500000 -2.8513e-04  0.0670
+wav/03a01Nc.wav 0 days 00:00:00        0 days 00:00:01         3.8935e-05  0.1516
+                0 days 00:00:00.500000 0 days 00:00:01.500000 -4.1219e-04  0.1059
+wav/16b10Wb.wav 0 days 00:00:00        0 days 00:00:01        -4.5467e-04  0.0819
+                0 days 00:00:00.500000 0 days 00:00:01.500000 -4.6149e-04  0.0974
+                0 days 00:00:01        0 days 00:00:02        -4.6923e-04  0.1141
+                0 days 00:00:01.500000 0 days 00:00:02.500000 -4.4670e-04  0.0955
 
 
 Feature interface for multi-channel input
@@ -192,10 +199,10 @@ on the following multi-channel signal.
 >>> signal_multi_channel.shape
 (4, 30372)
 >>> interface.process_signal(signal_multi_channel, sampling_rate)
-                                                   mean       std
+                                                 mean     std
 start                  end                                       
-0 days 00:00:00        0 days 00:00:01        -0.000329  0.098115
-0 days 00:00:00.500000 0 days 00:00:01.500000 -0.000285  0.067042
+0 days 00:00:00        0 days 00:00:01        -0.0003  0.0981
+0 days 00:00:00.500000 0 days 00:00:01.500000 -0.0003  0.0670
 
 To process the second and fourth channel,
 we create a new interface
@@ -226,20 +233,20 @@ number of channels (here 2).
     df = interface_multi_channel.process_signal(signal_multi_channel, sampling_rate)
 
 >>> df
-                                                 1              3          
-                                              mean  std      mean       std
+                                                 1            3          
+                                              mean  std    mean     std
 start                  end                                                 
-0 days 00:00:00        0 days 00:00:01         0.0  0.0  0.499671  0.098115
-0 days 00:00:00.500000 0 days 00:00:01.500000  0.0  0.0  0.499715  0.067042
+0 days 00:00:00        0 days 00:00:01         0.0  0.0  0.4997  0.0981
+0 days 00:00:00.500000 0 days 00:00:01.500000  0.0  0.0  0.4997  0.0670
 
 We can access the features of a specific
 channel by its index.
 
 >>> df[3]
-                                                   mean       std
+                                                 mean     std
 start                  end                                       
-0 days 00:00:00        0 days 00:00:01         0.499671  0.098115
-0 days 00:00:00.500000 0 days 00:00:01.500000  0.499715  0.067042
+0 days 00:00:00        0 days 00:00:01         0.4997  0.0981
+0 days 00:00:00.500000 0 days 00:00:01.500000  0.4997  0.0670
 
 
 Feature interface for external function
@@ -288,19 +295,19 @@ whereas the first dimension is optionally.
     )
 
 >>> interface.process_index(index, root=db.root)
-                                                                   mfcc-0  ...    mfcc-12
-file            start                  end                                 ...            
-wav/03a01Fa.wav 0 days 00:00:00        0 days 00:00:00.020000 -611.993286  ...   1.151396
-                0 days 00:00:00.010000 0 days 00:00:00.030000 -668.175842  ...  14.068543
-                0 days 00:00:00.020000 0 days 00:00:00.040000 -664.612793  ...   7.949757
-                0 days 00:00:00.030000 0 days 00:00:00.050000 -667.714722  ...  12.957479
-                0 days 00:00:00.040000 0 days 00:00:00.060000 -669.367432  ...   4.396849
-...                                                                   ...  ...        ...
-wav/16b10Wb.wav 0 days 00:00:02.480000 0 days 00:00:02.500000 -664.673584  ...   1.863654
-                0 days 00:00:02.490000 0 days 00:00:02.510000 -658.958069  ...   9.345045
-                0 days 00:00:02.500000 0 days 00:00:02.520000 -644.156494  ...   7.411011
-                0 days 00:00:02.510000 0 days 00:00:02.530000 -618.545898  ...  17.645359
-                0 days 00:00:02.520000 0 days 00:00:02.540000 -666.805237  ...   3.711080
+                                                                 mfcc-0  ...  mfcc-12
+file            start                  end                               ...         
+wav/03a01Fa.wav 0 days 00:00:00        0 days 00:00:00.020000 -611.9933  ...   1.1514
+                0 days 00:00:00.010000 0 days 00:00:00.030000 -668.1758  ...  14.0685
+                0 days 00:00:00.020000 0 days 00:00:00.040000 -664.6128  ...   7.9498
+                0 days 00:00:00.030000 0 days 00:00:00.050000 -667.7147  ...  12.9575
+                0 days 00:00:00.040000 0 days 00:00:00.060000 -669.3674  ...   4.3968
+...                                                                 ...  ...      ...
+wav/16b10Wb.wav 0 days 00:00:02.480000 0 days 00:00:02.500000 -664.6736  ...   1.8637
+                0 days 00:00:02.490000 0 days 00:00:02.510000 -658.9581  ...   9.3450
+                0 days 00:00:02.500000 0 days 00:00:02.520000 -644.1565  ...   7.4110
+                0 days 00:00:02.510000 0 days 00:00:02.530000 -618.5459  ...  17.6454
+                0 days 00:00:02.520000 0 days 00:00:02.540000 -666.8052  ...   3.7111
 <BLANKLINE>
 [605 rows x 13 columns]
 
@@ -337,11 +344,11 @@ and :class:`audobject.Object`.
     fex = MeanStd()
 
 >>> fex.process_index(index, root=db.root)
-                                                      mean       std
+                                                    mean     std
 file            start  end                                          
-wav/03a01Fa.wav 0 days 0 days 00:00:01.898250    -0.000311  0.082317
-wav/03a01Nc.wav 0 days 0 days 00:00:01.611250    -0.000312  0.125304
-wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999 -0.000464  0.095558
+wav/03a01Fa.wav 0 days 0 days 00:00:01.898250    -0.0003  0.0823
+wav/03a01Nc.wav 0 days 0 days 00:00:01.611250    -0.0003  0.1253
+wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999 -0.0005  0.0956
 
 The advantage of the feature extraction object is
 that we can save it to a YAML file
@@ -357,11 +364,11 @@ and re-instantiate it from there.
 >>> fex.to_yaml("mean-std.yaml")
 >>> fex2 = audobject.from_yaml("mean-std.yaml")
 >>> fex2.process_index(index, root=db.root)
-                                                      mean       std
+                                                    mean     std
 file            start  end                                          
-wav/03a01Fa.wav 0 days 0 days 00:00:01.898250    -0.000311  0.082317
-wav/03a01Nc.wav 0 days 0 days 00:00:01.611250    -0.000312  0.125304
-wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999 -0.000464  0.095558
+wav/03a01Fa.wav 0 days 0 days 00:00:01.898250    -0.0003  0.0823
+wav/03a01Nc.wav 0 days 0 days 00:00:01.611250    -0.0003  0.1253
+wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999 -0.0005  0.0956
 
 
 Segmentation interface
@@ -501,7 +508,7 @@ to select the appropriate f0 range.
             fmin=f0_range[gender.iloc[idx]][0],
             fmax=f0_range[gender.iloc[idx]][1],
             sr=sampling_rate,
-        ).mean()
+        ).mean().round(2)
         return y, gender.iloc[idx]
 
     interface = audinterface.Feature(
@@ -514,11 +521,11 @@ to select the appropriate f0 range.
     )
 
 >>> interface.process_index(gender.index, root=db.root)
-                                                                  f0  gender
+                                                       f0  gender
 file            start  end                                                  
-wav/03a01Fa.wav 0 days 0 days 00:00:01.898250      128.8100011977164    male
-wav/03a01Nc.wav 0 days 0 days 00:00:01.611250     111.63351213181389    male
-wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999  229.09341877352415  female
+wav/03a01Fa.wav 0 days 0 days 00:00:01.898250      128.81    male
+wav/03a01Nc.wav 0 days 0 days 00:00:01.611250      111.63    male
+wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999   229.09  female
 
 
 .. _audformat: https://audeering.github.io/audformat/

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -69,15 +69,15 @@ and create an interface for it using :class:`audinterface.Process`.
 
     interface = audinterface.Process(process_func=rms)
 
-The following three commands
-apply the algorithm
-and all return the same result
+You can then use one of the
+``process_files()``,
+``process_folder()``,
+or ``process_index()`` methods
+to apply the algorithm
+and return the result
 as a :class:`pandas.Series`.
 
->>> y = interface.process_files(files, root=db.root)
->>> y = interface.process_folder(folder, include_root=False)
->>> y = interface.process_index(index, root=db.root)
->>> y
+>>> interface.process_index(index, root=db.root)
 file             start   end
 wav/03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.6901
 wav/03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.0407

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -74,21 +74,10 @@ apply the algorithm
 and all return the same result
 as a :class:`pandas.Series`.
 
->>> interface.process_files(files, root=db.root)
-file             start   end
-wav/03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.6901
-wav/03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.0407
-wav/16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.3945
-dtype: float32
-
->>> interface.process_folder(folder, include_root=False)
-file             start   end
-03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.6901
-03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.0407
-16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.3945
-dtype: float32
-
->>> interface.process_index(index, root=db.root)
+>>> y = interface.process_files(files, root=db.root)
+>>> y = interface.process_folder(folder, include_root=False)
+>>> y = interface.process_index(index, root=db.root)
+>>> y
 file             start   end
 wav/03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.6901
 wav/03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.0407

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,53 +1,8 @@
-.. Specify pandas format output in cells
-.. jupyter-execute::
-    :hide-code:
-    :hide-output:
-
-    import pandas as pd
-
-    import audformat
-
-    def dataframe_to_html(df_original):
-        # Replace beginning of data path with ...
-        df = df_original.copy()
-        if len(df.index) > 0 and df.index.names[0] == "file":
-            old_path = r".+/audb/emodb/1.3.0/d3b62a9b/wav/"
-            new_path = r".../"
-            if audformat.is_segmented_index(df.index):
-                df.index = df.index.set_levels(
-                    df.index.levels[0].str.replace(
-                        old_path,
-                        new_path,
-                        regex=True,
-                    ),
-                    level=0,
-                )
-            else:
-                df.index = df.index.str.replace(old_path, new_path, regex=True)
-
-        return df.to_html(max_rows=6, max_cols=4)
-
-
-    def series_to_html(y):
-        df = y.to_frame()
-        df.columns = [""]
-        return dataframe_to_html(df)
-
-
-    def index_to_html(index):
-        df = pd.DataFrame(index=index)
-        return dataframe_to_html(df)
-
-
-    setattr(pd.Series, "_repr_html_", series_to_html)
-    setattr(pd.Index, "_repr_html_", index_to_html)
-    setattr(pd.DataFrame, "_repr_html_", dataframe_to_html)
-
 .. Specify version for storing and loading objects to YAML
-.. jupyter-execute::
-    :hide-code:
 
-    __version__ = "1.0.0"
+   invisible-code-block: python
+
+    >>> __version__ = "1.0.0"
 
 
 Usage
@@ -74,7 +29,7 @@ and define a list of files,
 a folder,
 and an index.
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audb
     import os
@@ -90,7 +45,6 @@ and an index.
         media=media,
         verbose=False,
     )
-
     files = list(db.files)
     folder = os.path.dirname(files[0])
     index = db["emotion"].index
@@ -104,7 +58,7 @@ value in dB.
 We first define the function
 and create an interface for it using :class:`audinterface.Process`.
 
-.. jupyter-execute::
+.. code-block:: python
 
     import audinterface
     import numpy as np
@@ -119,26 +73,59 @@ apply the algorithm
 and all return the same result
 as a :class:`pandas.Series`.
 
-.. jupyter-execute::
+.. doctest::
 
-    y = interface.process_files(files)
-    y = interface.process_folder(folder)
-    y = interface.process_index(index)
-    y
+    >>> interface.process_files(files)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    file             start   end
+    .../03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
+    .../03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040704
+    .../16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
+    dtype: float64
+
+.. doctest::
+
+    >>> interface.process_folder(folder)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    file             start   end
+    .../03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
+    .../03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040704
+    .../16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
+    dtype: float64
+
+.. doctest::
+
+    >>> interface.process_index(index)  # doctest: +NORMALIZE_WHITESPACE +ELLIPSIS
+    file             start   end
+    .../03a01Fa.wav  0 days  0 days 00:00:01.898250      -21.690142
+    .../03a01Nc.wav  0 days  0 days 00:00:01.611250      -18.040704
+    .../16b10Wb.wav  0 days  0 days 00:00:02.522499999   -20.394533
+    dtype: float64
 
 To calculate RMS with a sliding window,
 we create a new interface
 and set a window and hop duration.
 
-.. jupyter-execute::
+.. testcode::
 
     interface = audinterface.Process(
         process_func=rms,
         win_dur=1.0,
         hop_dur=0.5,
     )
-    y = interface.process_files(files)
-    y
+    interface.process_files(files)
+
+.. testoutput::
+
+    file             start                   end
+    .../03a01Fa.wav  0 days 00:00:00         0 days 00:00:01          -20.165248
+                     0 days 00:00:00.500000  0 days 00:00:01.500000   -23.472970
+    .../03a01Nc.wav  0 days 00:00:00         0 days 00:00:01          -16.386614
+                     0 days 00:00:00.500000  0 days 00:00:01.500000   -19.502597
+    .../16b10Wb.wav  0 days 00:00:00         0 days 00:00:01          -21.733990
+                     0 days 00:00:00.500000  0 days 00:00:01.500000   -20.233054
+                     0 days 00:00:01         0 days 00:00:02          -18.856522
+                     0 days 00:00:01.500000  0 days 00:00:02.500000   -20.403574
+    dtype: float64
+
 
 Feature interface
 -----------------
@@ -148,7 +135,7 @@ it is recommended to use :class:`audinterface.Feature`,
 which returns a :class:`pandas.DataFrame`
 and assigns names to the dimensions/features.
 
-.. jupyter-execute::
+.. testcode::
 
     def features(signal, sampling_rate):
         return [signal.mean(), signal.std()]
@@ -159,7 +146,11 @@ and assigns names to the dimensions/features.
     )
 
     df = interface.process_index(index)
-    df
+
+.. doctest::
+
+    >>> df
+    bla
 
 To calculate features with a sliding window,
 we create a new interface
@@ -169,7 +160,7 @@ By setting
 the windowing is automatically handled
 and single frames are passed on to the processing function.
 
-.. jupyter-execute::
+.. testcode::
 
     interface = audinterface.Feature(
         ["mean", "std"],
@@ -179,8 +170,11 @@ and single frames are passed on to the processing function.
         hop_dur=0.5,
     )
     df = interface.process_files(files)
-    df
 
+.. doctest::
+
+    >>> df
+    bla
 
 Feature interface for multi-channel input
 -----------------------------------------
@@ -192,7 +186,7 @@ We can prove this
 by running the previous interface
 on the following multi-channel signal.
 
-.. jupyter-execute::
+.. testcode::
 
     import audiofile
 
@@ -208,15 +202,23 @@ on the following multi-channel signal.
             signal + 0.5,
         ],
     )
-    signal_multi_channel.shape
 
-.. jupyter-execute::
+.. doctest::
+
+    >>> signal_multi_channel.shape
+    (4, 30372)
+
+.. testcode::
 
     df = interface.process_signal(
         signal_multi_channel,
         sampling_rate,
     )
-    df
+
+.. doctest::
+
+    >>> df
+    bla
 
 To process the second and fourth channel,
 we create a new interface
@@ -232,7 +234,7 @@ the processing function must
 return an array with the correct
 number of channels (here 2).
 
-.. jupyter-execute::
+.. code-block::
 
     interface_multi_channel = audinterface.Feature(
         ["mean", "std"],
@@ -248,14 +250,19 @@ number of channels (here 2).
         signal_multi_channel,
         sampling_rate,
     )
-    df
+
+.. doctest::
+
+    >>> df
+    bla
 
 We can access the features of a specific
 channel by its index.
 
-.. jupyter-execute::
+.. doctest::
 
-    df[3]
+    >>> df[3]
+    bla
 
 
 Feature interface for external function
@@ -277,7 +284,7 @@ and returning the values in the correct shape,
 namely ``(num_channels, num_features, num_frames)``,
 whereas the first dimension is optionally.
 
-.. jupyter-execute::
+.. testcode::
 
     import librosa
 
@@ -303,7 +310,11 @@ whereas the first dimension is optionally.
         hop_dur=0.01,
     )
     df = interface.process_index(index)
-    df
+
+.. doctest::
+
+    >>> df
+    bla
 
 
 Serializable feature interface
@@ -320,7 +331,7 @@ we create a class that inherits
 from :class:`audinterface.Feature`
 and :class:`audobject.Object`.
 
-.. jupyter-execute::
+.. testcode::
 
     import audobject
 
@@ -337,18 +348,26 @@ and :class:`audobject.Object`.
 
     fex = MeanStd()
     df = fex.process_index(index)
-    df
+
+.. doctest::
+
+    >>> df
+    bla
 
 The advantage of the feature extraction object is
 that we can save it to a YAML file
 and re-instantiate it from there.
 
-.. jupyter-execute::
+.. testcode::
 
     fex.to_yaml("mean-std.yaml")
     fex2 = audobject.from_yaml("mean-std.yaml")
     df = fex2.process_index(index)
-    df
+
+.. doctest::
+
+    >>> df
+    bla
 
 
 Segmentation interface
@@ -360,7 +379,7 @@ which returns a segmented index conform to audformat_.
 An example for such a processing function
 would be a voice activity detection algorithm.
 
-.. jupyter-execute::
+.. testcode::
 
     import auditok
 
@@ -393,7 +412,11 @@ would be a voice activity detection algorithm.
 
     interface = audinterface.Segment(process_func=segments)
     idx = interface.process_file(files[0])
-    idx
+
+.. doctest::
+
+    >>> idx
+    bla
 
 Sometimes,
 it is required that a table
@@ -443,14 +466,17 @@ The following processing function
 returns the values of
 ``"idx"`` and ``"file"``.
 
-.. jupyter-execute::
+.. testcode::
 
     def special_args(signal, sampling_rate, idx, file):
         return idx, os.path.basename(file)
 
     interface = audinterface.Process(process_func=special_args)
     y = interface.process_files(files)
-    y
+
+.. doctest::
+
+    >>> y
 
 For instance,
 we can pass a list with gender labels
@@ -458,7 +484,7 @@ to the processing function
 and use the running index
 to select the appropriate f0 range.
 
-.. jupyter-execute::
+.. testcode::
 
     gender = db["files"]["speaker"].get(map="gender")  # gender per file
     f0_range = {
@@ -485,7 +511,11 @@ to select the appropriate f0 range.
         },
     )
     df = interface.process_index(gender.index)
-    df
+
+.. doctest::
+
+    >>> df
+    bla
 
 
 .. _audformat: https://audeering.github.io/audformat/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,12 +69,10 @@ skip = './audinterface.egg-info,./build,./docs/api,./docs/_templates,./misc'
 cache_dir = '.cache/pytest'
 xfail_strict = true
 addopts = '''
-    --doctest-plus
     --cov=audinterface
     --cov-fail-under=100
     --cov-report term-missing
     --cov-report xml
-    --ignore=docs/
 '''
 
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,3 +4,4 @@ audobject >=0.7.5
 pytest
 pytest-doctestplus
 pytest-cov
+sybil

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,9 @@
 audeer >=1.21.0
 audb
+auditok
 audobject >=0.7.5
+librosa
 pytest
 pytest-cov
+soxr >=0.4.0b1  # for numpy 2, https://github.com/dofuuz/python-soxr/issues/28
 sybil

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,6 +2,5 @@ audeer >=1.21.0
 audb
 audobject >=0.7.5
 pytest
-pytest-doctestplus
 pytest-cov
 sybil


### PR DESCRIPTION
So far we used the following setup for ensuring the expected code output in the documentation:

* Use the [doctest-plus](https://github.com/scientific-python/pytest-doctestplus) pytest plugin for testing the docstring examples
* Use the [jupyter-sphinx](https://github.com/jupyter/jupyter-sphinx) sphinx extension for running any code blocks in the usage documentation and presenting its output

The disadvantage of [jupyter-sphinx](https://github.com/jupyter/jupyter-sphinx) is that it requires a lot of dependencies, and we cannot control if the output of the code looks as expected. We can only test if the code runs without any error. In addition, we cannot directly use `ELLIPSIS` to change parts of the output, e.g. to hide absolute paths or strings that are too long, but needed to write extra format functions to handle such cases. Another disadvantage was that it bundles testing and building of the documentation.

This pull request proposes to use [sybil](https://github.com/simplistix/sybil) as a replacement for both [doctest-plus](https://github.com/scientific-python/pytest-doctestplus) and [jupyter-sphinx](https://github.com/jupyter/jupyter-sphinx).

[doctest-plus](https://github.com/scientific-python/pytest-doctestplus) would be a strong candidate to use instead of [sybil](https://github.com/simplistix/sybil) as it also provides the `FLOAT_CMP` flag to allow to compare floats only to a certain digit. But the disadvantage of [doctest-plus](https://github.com/scientific-python/pytest-doctestplus) is that you need to write all code blocks inside `>>>` statements (even the hidden `.. testsetup` and `.. testcleanup` directives), which I find quite cumbersome.

[sphinx.ext.doctest](https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html) allows for better writing of code than [doctest-plus](https://github.com/scientific-python/pytest-doctestplus), but it needs to be executed by `sphinx` instead of `pytest`, and it is limited to test the code inside the documentation, not inside docstrings of the Python package.

The resulting output of the usage documentation also changes slightly,
as we now present the results not as rendered tables,
but as classical doctest output, e.g.

| main | pull request |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/ef912b55-c9b7-4800-a47c-e376fafec2d1) | ![image](https://github.com/user-attachments/assets/1f5e91d9-1031-4eb3-a725-7ece399a1d11) |

