### PR TITLE
Update progress bars every second

### DIFF
--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -440,6 +440,7 @@ class Process:
             multiprocessing=self.multiprocessing,
             progress_bar=verbose,
             task_description=f"Process {len(files)} files",
+            maximum_refresh_time=1,
         )
         self.verbose = verbose
 
@@ -539,6 +540,7 @@ class Process:
             multiprocessing=self.multiprocessing,
             progress_bar=self.verbose,
             task_description=f"Process {len(index)} segments",
+            maximum_refresh_time=1,
         )
 
         y = list(itertools.chain.from_iterable([x[0] for x in xs]))
@@ -841,6 +843,7 @@ class Process:
             multiprocessing=self.multiprocessing,
             progress_bar=self.verbose,
             task_description=f"Process {len(index)} segments",
+            maximum_refresh_time=1,
         )
 
         y = list(itertools.chain.from_iterable([x[0] for x in xs]))

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -199,6 +199,7 @@ class ProcessWithContext:
             files,
             total=len(files),
             disable=not self.verbose,
+            maximum_refresh_time=1,
         ) as pbar:
             for idx, file in enumerate(pbar):
                 if self.verbose:  # pragma: no cover

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -753,6 +753,7 @@ class Segment:
             multiprocessing=self.process.multiprocessing,
             progress_bar=self.process.verbose,
             task_description=f"Process {len(index)} segments",
+            maximum_refresh_time=1,
         )
 
         files = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 requires-python = '>=3.9'
 dependencies = [
-    'audeer >=1.18.0',
+    'audeer >=2.1.1',
     'audformat >=1.0.1,<2.0.0',
     'audiofile >=1.3.0',
     'audmath >=1.4.1',


### PR DESCRIPTION
Makes use of the new `maximum_refresh_time` argument of `audeer.progress_bar()` and `audeer.run_tasks()`, which was introduced in `audeer` v2.1.0 and enhanced in v2.1.1.

We set `maximum_refresh_time=1` to update the progress bar at least once every second, and require `audeer >=2.1.1` as a dependency.

## Summary by Sourcery

Update progress bars to refresh every second by utilizing the new maximum_refresh_time argument from audeer v2.1.1 and adjust the audeer dependency version accordingly.

Enhancements:
- Set the maximum refresh time for progress bars to 1 second using the new argument in audeer v2.1.1.

Build:
- Update the audeer dependency to version 2.1.1 in pyproject.toml.