### PR TITLE
CI: install portaudio

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,11 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Prepare Macos
+      run: |
+        brew install portaudio
+      if matrix.os == 'macos-latest'
+
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Prepare Ubuntu
       run: |
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1 sox
+        sudo apt-get install --no-install-recommends --yes libsndfile1 sox portaudio19-dev
       if: matrix.os == 'ubuntu-latest'
 
     - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Prepare Macos
       run: |
         brew install portaudio
-      if matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-latest'
 
     - name: Prepare Ubuntu
       run: |


### PR DESCRIPTION
To fix the tests under Mac and Ubuntu, we need to install `portaudio`, compare https://github.com/audeering/audinterface/actions/runs/11955509905/job/33328050030?pr=181.

## Summary by Sourcery

CI:
- Add installation step for portaudio on MacOS in CI workflow to ensure compatibility with latest runner versions.