### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-audb
+audb >=1.11.0
 audeer
 sphinx
 sphinx-apipages >=0.1.2

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -392,8 +392,8 @@ would be a voice activity detection algorithm.
         index = pd.MultiIndex.from_tuples(
             [
                 (
-                    pd.Timedelta(region.meta.start, unit="s"),
-                    pd.Timedelta(region.meta.end, unit="s"),
+                    pd.Timedelta(region.start, unit="s"),
+                    pd.Timedelta(region.end, unit="s"),
                 )
                 for region in regions
             ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.9'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 audeer >=1.21.0
-audb
+audb >=1.11.0
 auditok
 audobject >=0.7.5
 librosa

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,6 @@
 audeer >=1.21.0
 audb >=1.11.0
-auditok
+auditok >=0.3.0
 audobject >=0.7.5
 librosa
 pytest


### PR DESCRIPTION
Adds Python 3.12 as supported version to the Python package and enables tests for it in Ubuntu runners.

## Summary by Sourcery

Add support for Python 3.12 by updating the project configuration and documentation, and enable CI testing for this version on Ubuntu runners.

New Features:
- Add support for Python 3.12 in the project.

CI:
- Enable testing for Python 3.12 on Ubuntu runners.

Documentation:
- Update documentation to reflect support for Python 3.12.