### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
 requires-python = '>=3.9'


### PR DESCRIPTION
Adds Python 3.13 as supported version to the Python package and enables tests for it in Ubuntu runners.

## Summary by Sourcery

Add support for Python 3.13 by updating the project configuration and enabling CI tests for this version on Ubuntu runners.

Enhancements:
- Add support for Python 3.13 in the project configuration.

CI:
- Enable testing for Python 3.13 on Ubuntu runners.