### PR TITLE
TST: require librosa>=0.11.0 for F0 extraction

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -512,9 +512,9 @@ to select the appropriate f0 range.
 >>> interface.process_index(gender.index, root=db.root)
                                                        f0  gender
 file            start  end                                                  
-wav/03a01Fa.wav 0 days 0 days 00:00:01.898250      128.81    male
-wav/03a01Nc.wav 0 days 0 days 00:00:01.611250      111.63    male
-wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999   229.09  female
+wav/03a01Fa.wav 0 days 0 days 00:00:01.898250       134.0    male
+wav/03a01Nc.wav 0 days 0 days 00:00:01.611250      113.16    male
+wav/16b10Wb.wav 0 days 0 days 00:00:02.522499999   234.86  female
 
 
 .. _audformat: https://audeering.github.io/audformat/

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ audeer >=1.21.0
 audb >=1.11.0
 auditok >=0.3.0
 audobject >=0.7.5
-librosa
+librosa ==0.11.0
 pytest
 pytest-cov
 soxr >=0.4.0b1  # for numpy 2, https://github.com/dofuuz/python-soxr/issues/28

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,7 +2,7 @@ audeer >=1.21.0
 audb >=1.11.0
 auditok >=0.3.0
 audobject >=0.7.5
-librosa ==0.11.0
+librosa >=0.11.0
 pytest
 pytest-cov
 soxr >=0.4.0b1  # for numpy 2, https://github.com/dofuuz/python-soxr/issues/28


### PR DESCRIPTION
Updates the usage example, which uses `librosa` for F0 extraction to use `librosa>=0.11.0` and adjust the output values accordingly.

![image](https://github.com/user-attachments/assets/b5eb70e6-d1af-4672-9f4e-30029e5b0240)

## Summary by Sourcery

Require librosa>=0.11.0 for F0 extraction and update usage example accordingly

Documentation:
- Adjust F0 extraction usage example to match updated librosa output values

Tests:
- Bump librosa dependency to >=0.11.0 in tests requirements