### PR TITLE
Add comments for dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ dev = [
     'audobject >=0.7.5',
     'faster-whisper',  # for usage example with ASR
     'librosa >=0.11.0',
-    'onnxruntime ==1.19.2 ; python_version == "3.9"',
-    'onnxruntime ; python_version >= "3.10"',
+    'onnxruntime ==1.19.2 ; python_version == "3.9"',  # for usage example with ASR
+    'onnxruntime ; python_version >= "3.10"',  # for usage example with ASR
     'pytest',
     'pytest-cov',
     'soxr >=0.4.0b1',  # for numpy 2


### PR DESCRIPTION
Add comments we forgot in https://github.com/audeering/audinterface/pull/192 to indicate why we depend on `onnxruntime`.

## Summary by Sourcery

Chores:
- Annotate onnxruntime entries for Python 3.9 and 3.10+ with “for usage example with ASR” comments in pyproject.toml