### PR TITLE
Update syntax to Python >=3.9

### DIFF
--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
 import errno
 import inspect
 import os
-import typing
 
 import numpy as np
 import pandas as pd
@@ -246,17 +249,17 @@ class Feature:
 
     def __init__(
         self,
-        feature_names: typing.Union[str, typing.Sequence[str]],
+        feature_names: str | Sequence[str],
         *,
         name: str = None,
-        params: typing.Dict = None,
-        process_func: typing.Callable[..., typing.Any] = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        params: dict = None,
+        process_func: Callable[..., object] = None,
+        process_func_args: dict[str, object] = None,
         process_func_is_mono: bool = False,
         process_func_applies_sliding_window: bool = False,
         sampling_rate: int = None,
         resample: bool = False,
-        channels: typing.Union[int, typing.Sequence[int]] = 0,
+        channels: int | Sequence[int] = 0,
         mixdown: bool = False,
         win_dur: Timestamp = None,
         hop_dur: Timestamp = None,
@@ -264,7 +267,7 @@ class Feature:
         max_signal_dur: Timestamp = None,
         segment: Segment = None,
         keep_nat: bool = False,
-        num_workers: typing.Optional[int] = 1,
+        num_workers: int | None = 1,
         multiprocessing: bool = False,
         verbose: bool = False,
     ):
@@ -362,7 +365,7 @@ class Feature:
         start: Timestamp = None,
         end: Timestamp = None,
         root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Extract features from an audio file.
 
@@ -399,12 +402,12 @@ class Feature:
 
     def process_files(
         self,
-        files: typing.Sequence[str],
+        files: Sequence[str],
         *,
         starts: Timestamps = None,
         ends: Timestamps = None,
         root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Extract features for a list of files.
 
@@ -449,7 +452,7 @@ class Feature:
         *,
         filetype: str = "wav",
         include_root: bool = True,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Extract features from files in a folder.
 
@@ -502,7 +505,7 @@ class Feature:
         preserve_index: bool = False,
         root: str = None,
         cache_root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Extract features from an index conform to audformat_.
 
@@ -575,7 +578,7 @@ class Feature:
         file: str = None,
         start: Timestamp = None,
         end: Timestamp = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Extract features for an audio signal.
 
@@ -627,7 +630,7 @@ class Feature:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.MultiIndex,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Split a signal into segments and extract features for each segment.
 
@@ -676,7 +679,7 @@ class Feature:
         """
         return frame.values.T.reshape(self.num_channels, self.num_features, -1)
 
-    def _reshape_3d(self, features: typing.Union[np.ndarray, pd.Series]):
+    def _reshape_3d(self, features: np.ndarray | pd.Series):
         r"""Reshape to [n_channels, n_features, n_frames]."""
         features = np.array(features)
         features = np.atleast_1d(features)

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -251,21 +251,21 @@ class Feature:
         self,
         feature_names: str | Sequence[str],
         *,
-        name: str = None,
-        params: dict = None,
-        process_func: Callable[..., object] = None,
-        process_func_args: dict[str, object] = None,
+        name: str | None = None,
+        params: dict | None = None,
+        process_func: Callable[..., object] | None = None,
+        process_func_args: dict[str, object] | None = None,
         process_func_is_mono: bool = False,
         process_func_applies_sliding_window: bool = False,
-        sampling_rate: int = None,
+        sampling_rate: int | None = None,
         resample: bool = False,
         channels: int | Sequence[int] = 0,
         mixdown: bool = False,
-        win_dur: Timestamp = None,
-        hop_dur: Timestamp = None,
-        min_signal_dur: Timestamp = None,
-        max_signal_dur: Timestamp = None,
-        segment: Segment = None,
+        win_dur: Timestamp | None = None,
+        hop_dur: Timestamp | None = None,
+        min_signal_dur: Timestamp | None = None,
+        max_signal_dur: Timestamp | None = None,
+        segment: Segment | None = None,
         keep_nat: bool = False,
         num_workers: int | None = 1,
         multiprocessing: bool = False,
@@ -362,10 +362,10 @@ class Feature:
         self,
         file: str,
         *,
-        start: Timestamp = None,
-        end: Timestamp = None,
-        root: str = None,
-        process_func_args: dict[str, object] = None,
+        start: Timestamp | None = None,
+        end: Timestamp | None = None,
+        root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Extract features from an audio file.
 
@@ -404,10 +404,10 @@ class Feature:
         self,
         files: Sequence[str],
         *,
-        starts: Timestamps = None,
-        ends: Timestamps = None,
-        root: str = None,
-        process_func_args: dict[str, object] = None,
+        starts: Timestamps | None = None,
+        ends: Timestamps | None = None,
+        root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Extract features for a list of files.
 
@@ -452,7 +452,7 @@ class Feature:
         *,
         filetype: str = "wav",
         include_root: bool = True,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Extract features from files in a folder.
 
@@ -503,9 +503,9 @@ class Feature:
         index: pd.Index,
         *,
         preserve_index: bool = False,
-        root: str = None,
-        cache_root: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        cache_root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Extract features from an index conform to audformat_.
 
@@ -575,10 +575,10 @@ class Feature:
         signal: np.ndarray,
         sampling_rate: int,
         *,
-        file: str = None,
-        start: Timestamp = None,
-        end: Timestamp = None,
-        process_func_args: dict[str, object] = None,
+        file: str | None = None,
+        start: Timestamp | None = None,
+        end: Timestamp | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Extract features for an audio signal.
 
@@ -630,7 +630,7 @@ class Feature:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.MultiIndex,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Split a signal into segments and extract features for each segment.
 

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
 import errno
 import inspect
 import itertools
 import os
-import typing
 
 import numpy as np
 import pandas as pd
@@ -155,12 +158,12 @@ class Process:
     def __init__(
         self,
         *,
-        process_func: typing.Callable[..., typing.Any] = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func: Callable[..., object] = None,
+        process_func_args: dict[str, object] = None,
         process_func_is_mono: bool = False,
         sampling_rate: int = None,
         resample: bool = False,
-        channels: typing.Union[int, typing.Sequence[int]] = None,
+        channels: int | Sequence[int] = None,
         mixdown: bool = False,
         win_dur: Timestamp = None,
         hop_dur: Timestamp = None,
@@ -168,7 +171,7 @@ class Process:
         max_signal_dur: Timestamp = None,
         segment: Segment = None,
         keep_nat: bool = False,
-        num_workers: typing.Optional[int] = 1,
+        num_workers: int | None = 1,
         multiprocessing: bool = False,
         verbose: bool = False,
     ):
@@ -244,12 +247,12 @@ class Process:
         root: str = None,
         start: pd.Timedelta = None,
         end: pd.Timedelta = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
-    ) -> typing.Tuple[
-        typing.List[typing.Any],
-        typing.List[str],
-        typing.List[pd.Timedelta],
-        typing.List[pd.Timedelta],
+        process_func_args: dict[str, object] = None,
+    ) -> tuple[
+        list[object],
+        list[str],
+        list[pd.Timedelta],
+        list[pd.Timedelta],
     ]:
         if start is not None:
             start = utils.to_timedelta(start, self.sampling_rate)
@@ -303,7 +306,7 @@ class Process:
         start: Timestamp = None,
         end: Timestamp = None,
         root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Process the content of an audio file.
 
@@ -358,12 +361,12 @@ class Process:
 
     def process_files(
         self,
-        files: typing.Sequence[str],
+        files: Sequence[str],
         *,
         starts: Timestamps = None,
         ends: Timestamps = None,
         root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Process a list of files.
 
@@ -460,7 +463,7 @@ class Process:
         *,
         filetype: str = "wav",
         include_root: bool = True,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Process files in a folder.
 
@@ -512,8 +515,8 @@ class Process:
     def _process_index_wo_segment(
         self,
         index: pd.Index,
-        root: typing.Optional[str],
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        root: str | None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Like process_index, but does not apply segmentation."""
         if index.empty:
@@ -560,7 +563,7 @@ class Process:
         preserve_index: bool = False,
         root: str = None,
         cache_root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Process from an index conform to audformat_.
 
@@ -642,12 +645,12 @@ class Process:
         file: str = None,
         start: pd.Timedelta = None,
         end: pd.Timedelta = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
-    ) -> typing.Tuple[
-        typing.List[typing.Any],
-        typing.List[str],
-        typing.List[pd.Timedelta],
-        typing.List[pd.Timedelta],
+        process_func_args: dict[str, object] = None,
+    ) -> tuple[
+        list[object],
+        list[str],
+        list[pd.Timedelta],
+        list[pd.Timedelta],
     ]:
         signal = np.atleast_2d(signal)
 
@@ -721,7 +724,7 @@ class Process:
         file: str = None,
         start: Timestamp = None,
         end: Timestamp = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Process audio signal and return result.
 
@@ -799,7 +802,7 @@ class Process:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Like process_signal_from_index, but does not apply segmentation."""
         if index.empty:
@@ -865,7 +868,7 @@ class Process:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Split a signal into segments and process each segment.
 
@@ -921,8 +924,8 @@ class Process:
         idx: int = 0,
         root: str = None,
         file: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
-    ) -> typing.Any:
+        process_func_args: dict[str, object] = None,
+    ) -> object:
         r"""Call processing function, possibly pass special args."""
         signal, sampling_rate = utils.preprocess_signal(
             signal,
@@ -980,7 +983,7 @@ class Process:
         self,
         signal: np.ndarray,
         sampling_rate: int,
-    ) -> typing.Any:
+    ) -> object:
         r"""Apply processing to signal.
 
         This function processes the signal **without** transforming the output

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -158,18 +158,18 @@ class Process:
     def __init__(
         self,
         *,
-        process_func: Callable[..., object] = None,
-        process_func_args: dict[str, object] = None,
+        process_func: Callable[..., object] | None = None,
+        process_func_args: dict[str, object] | None = None,
         process_func_is_mono: bool = False,
-        sampling_rate: int = None,
+        sampling_rate: int | None = None,
         resample: bool = False,
-        channels: int | Sequence[int] = None,
+        channels: int | Sequence[int] | None = None,
         mixdown: bool = False,
-        win_dur: Timestamp = None,
-        hop_dur: Timestamp = None,
-        min_signal_dur: Timestamp = None,
-        max_signal_dur: Timestamp = None,
-        segment: Segment = None,
+        win_dur: Timestamp | None = None,
+        hop_dur: Timestamp | None = None,
+        min_signal_dur: Timestamp | None = None,
+        max_signal_dur: Timestamp | None = None,
+        segment: Segment | None = None,
         keep_nat: bool = False,
         num_workers: int | None = 1,
         multiprocessing: bool = False,
@@ -244,10 +244,10 @@ class Process:
         file: str,
         *,
         idx: int = 0,
-        root: str = None,
-        start: pd.Timedelta = None,
-        end: pd.Timedelta = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        start: pd.Timedelta | None = None,
+        end: pd.Timedelta | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> tuple[
         list[object],
         list[str],
@@ -303,10 +303,10 @@ class Process:
         self,
         file: str,
         *,
-        start: Timestamp = None,
-        end: Timestamp = None,
-        root: str = None,
-        process_func_args: dict[str, object] = None,
+        start: Timestamp | None = None,
+        end: Timestamp | None = None,
+        root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Process the content of an audio file.
 
@@ -363,10 +363,10 @@ class Process:
         self,
         files: Sequence[str],
         *,
-        starts: Timestamps = None,
-        ends: Timestamps = None,
-        root: str = None,
-        process_func_args: dict[str, object] = None,
+        starts: Timestamps | None = None,
+        ends: Timestamps | None = None,
+        root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Process a list of files.
 
@@ -463,7 +463,7 @@ class Process:
         *,
         filetype: str = "wav",
         include_root: bool = True,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Process files in a folder.
 
@@ -516,7 +516,7 @@ class Process:
         self,
         index: pd.Index,
         root: str | None,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Like process_index, but does not apply segmentation."""
         if index.empty:
@@ -561,9 +561,9 @@ class Process:
         index: pd.Index,
         *,
         preserve_index: bool = False,
-        root: str = None,
-        cache_root: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        cache_root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Process from an index conform to audformat_.
 
@@ -641,11 +641,11 @@ class Process:
         sampling_rate: int,
         *,
         idx: int = 0,
-        root: str = None,
-        file: str = None,
-        start: pd.Timedelta = None,
-        end: pd.Timedelta = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        file: str | None = None,
+        start: pd.Timedelta | None = None,
+        end: pd.Timedelta | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> tuple[
         list[object],
         list[str],
@@ -721,10 +721,10 @@ class Process:
         signal: np.ndarray,
         sampling_rate: int,
         *,
-        file: str = None,
-        start: Timestamp = None,
-        end: Timestamp = None,
-        process_func_args: dict[str, object] = None,
+        file: str | None = None,
+        start: Timestamp | None = None,
+        end: Timestamp | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Process audio signal and return result.
 
@@ -802,7 +802,7 @@ class Process:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Like process_signal_from_index, but does not apply segmentation."""
         if index.empty:
@@ -868,7 +868,7 @@ class Process:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Split a signal into segments and process each segment.
 
@@ -922,9 +922,9 @@ class Process:
         sampling_rate: int,
         *,
         idx: int = 0,
-        root: str = None,
-        file: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        file: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> object:
         r"""Call processing function, possibly pass special args."""
         signal, sampling_rate = utils.preprocess_signal(

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import collections
+from collections.abc import Callable
+from collections.abc import Sequence
 import inspect
 import itertools
-import typing
 
 import numpy as np
 import pandas as pd
@@ -12,7 +15,7 @@ import audformat
 from audinterface.core import utils
 
 
-def identity(signal, sampling_rate, starts, ends) -> typing.List[np.ndarray]:
+def identity(signal, sampling_rate, starts, ends) -> list[np.ndarray]:
     r"""Default processing function.
 
     This function is used,
@@ -115,11 +118,11 @@ class ProcessWithContext:
     def __init__(
         self,
         *,
-        process_func: typing.Callable[..., typing.Sequence[typing.Any]] = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func: Callable[..., Sequence[object]] = None,
+        process_func_args: dict[str, object] = None,
         sampling_rate: int = None,
         resample: bool = False,
-        channels: typing.Union[int, typing.Sequence[int]] = None,
+        channels: int | Sequence[int] = None,
         mixdown: bool = False,
         verbose: bool = False,
     ):
@@ -160,7 +163,7 @@ class ProcessWithContext:
         index: pd.Index,
         *,
         root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Process from a segmented index conform to audformat_.
 
@@ -236,8 +239,8 @@ class ProcessWithContext:
         idx: int = 0,
         root: str = None,
         file: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
-    ) -> typing.Any:
+        process_func_args: dict[str, object] = None,
+    ) -> object:
         starts_i, ends_i = utils.segments_to_indices(
             signal,
             sampling_rate,
@@ -266,7 +269,7 @@ class ProcessWithContext:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Series:
         r"""Split a signal into segments and process each segment.
 
@@ -315,14 +318,14 @@ class ProcessWithContext:
         self,
         signal: np.ndarray,
         sampling_rate: int,
-        starts: typing.Sequence[int],
-        ends: typing.Sequence[int],
+        starts: Sequence[int],
+        ends: Sequence[int],
         *,
         idx: int = 0,
         root: str = None,
         file: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
-    ) -> typing.Any:
+        process_func_args: dict[str, object] = None,
+    ) -> object:
         r"""Call processing function, possibly pass special args."""
         signal, sampling_rate = utils.preprocess_signal(
             signal,
@@ -356,9 +359,9 @@ class ProcessWithContext:
         self,
         signal: np.ndarray,
         sampling_rate: int,
-        starts: typing.Sequence[int],
-        ends: typing.Sequence[int],
-    ) -> typing.Any:
+        starts: Sequence[int],
+        ends: Sequence[int],
+    ) -> object:
         r"""Apply processing to signal.
 
         This function processes the signal **without** transforming the output

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -118,11 +118,11 @@ class ProcessWithContext:
     def __init__(
         self,
         *,
-        process_func: Callable[..., Sequence[object]] = None,
-        process_func_args: dict[str, object] = None,
-        sampling_rate: int = None,
+        process_func: Callable[..., Sequence[object]] | None = None,
+        process_func_args: dict[str, object] | None = None,
+        sampling_rate: int | None = None,
         resample: bool = False,
-        channels: int | Sequence[int] = None,
+        channels: int | Sequence[int] | None = None,
         mixdown: bool = False,
         verbose: bool = False,
     ):
@@ -162,8 +162,8 @@ class ProcessWithContext:
         self,
         index: pd.Index,
         *,
-        root: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Process from a segmented index conform to audformat_.
 
@@ -237,9 +237,9 @@ class ProcessWithContext:
         index: pd.Index,
         *,
         idx: int = 0,
-        root: str = None,
-        file: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        file: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> object:
         starts_i, ends_i = utils.segments_to_indices(
             signal,
@@ -269,7 +269,7 @@ class ProcessWithContext:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series:
         r"""Split a signal into segments and process each segment.
 
@@ -322,9 +322,9 @@ class ProcessWithContext:
         ends: Sequence[int],
         *,
         idx: int = 0,
-        root: str = None,
-        file: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        file: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> object:
         r"""Call processing function, possibly pass special args."""
         signal, sampling_rate = utils.preprocess_signal(

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -234,15 +234,15 @@ class Segment:
     def __init__(
         self,
         *,
-        process_func: Callable[..., pd.MultiIndex] = None,
-        process_func_args: dict[str, object] = None,
+        process_func: Callable[..., pd.MultiIndex] | None = None,
+        process_func_args: dict[str, object] | None = None,
         invert: bool = False,
-        sampling_rate: int = None,
+        sampling_rate: int | None = None,
         resample: bool = False,
-        channels: int | Sequence[int] = None,
+        channels: int | Sequence[int] | None = None,
         mixdown: bool = False,
-        min_signal_dur: Timestamp = None,
-        max_signal_dur: Timestamp = None,
+        min_signal_dur: Timestamp | None = None,
+        max_signal_dur: Timestamp | None = None,
         keep_nat: bool = False,
         num_workers: int | None = 1,
         multiprocessing: bool = False,
@@ -284,10 +284,10 @@ class Segment:
         self,
         file: str,
         *,
-        start: Timestamp = None,
-        end: Timestamp = None,
-        root: str = None,
-        process_func_args: dict[str, object] = None,
+        start: Timestamp | None = None,
+        end: Timestamp | None = None,
+        root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Index:
         r"""Segment the content of an audio file.
 
@@ -335,10 +335,10 @@ class Segment:
         self,
         files: Sequence[str],
         *,
-        starts: Timestamps = None,
-        ends: Timestamps = None,
-        root: str = None,
-        process_func_args: dict[str, object] = None,
+        starts: Timestamps | None = None,
+        ends: Timestamps | None = None,
+        root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Index:
         r"""Segment a list of files.
 
@@ -397,7 +397,7 @@ class Segment:
         *,
         filetype: str = "wav",
         include_root: bool = True,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Index:
         r"""Segment files in a folder.
 
@@ -450,9 +450,9 @@ class Segment:
         self,
         index: pd.Index,
         *,
-        root: str = None,
-        cache_root: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        cache_root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Index:
         r"""Segment files or segments from an index.
 
@@ -512,9 +512,9 @@ class Segment:
         self,
         table: pd.Series | pd.DataFrame,
         *,
-        root: str = None,
-        cache_root: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        cache_root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Series | pd.DataFrame:
         r"""Segment files or segments from a table.
 
@@ -616,10 +616,10 @@ class Segment:
         signal: np.ndarray,
         sampling_rate: int,
         *,
-        file: str = None,
-        start: Timestamp = None,
-        end: Timestamp = None,
-        process_func_args: dict[str, object] = None,
+        file: str | None = None,
+        start: Timestamp | None = None,
+        end: Timestamp | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Index:
         r"""Segment audio signal.
 
@@ -690,7 +690,7 @@ class Segment:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.Index:
         r"""Segment parts of a signal.
 

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
 import errno
 import os
-import typing
 
 import numpy as np
 import pandas as pd
@@ -231,17 +234,17 @@ class Segment:
     def __init__(
         self,
         *,
-        process_func: typing.Callable[..., pd.MultiIndex] = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func: Callable[..., pd.MultiIndex] = None,
+        process_func_args: dict[str, object] = None,
         invert: bool = False,
         sampling_rate: int = None,
         resample: bool = False,
-        channels: typing.Union[int, typing.Sequence[int]] = None,
+        channels: int | Sequence[int] = None,
         mixdown: bool = False,
         min_signal_dur: Timestamp = None,
         max_signal_dur: Timestamp = None,
         keep_nat: bool = False,
-        num_workers: typing.Optional[int] = 1,
+        num_workers: int | None = 1,
         multiprocessing: bool = False,
         verbose: bool = False,
     ):
@@ -284,7 +287,7 @@ class Segment:
         start: Timestamp = None,
         end: Timestamp = None,
         root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Index:
         r"""Segment the content of an audio file.
 
@@ -330,12 +333,12 @@ class Segment:
 
     def process_files(
         self,
-        files: typing.Sequence[str],
+        files: Sequence[str],
         *,
         starts: Timestamps = None,
         ends: Timestamps = None,
         root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Index:
         r"""Segment a list of files.
 
@@ -394,7 +397,7 @@ class Segment:
         *,
         filetype: str = "wav",
         include_root: bool = True,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Index:
         r"""Segment files in a folder.
 
@@ -449,7 +452,7 @@ class Segment:
         *,
         root: str = None,
         cache_root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Index:
         r"""Segment files or segments from an index.
 
@@ -507,12 +510,12 @@ class Segment:
 
     def process_table(
         self,
-        table: typing.Union[pd.Series, pd.DataFrame],
+        table: pd.Series | pd.DataFrame,
         *,
         root: str = None,
         cache_root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
-    ) -> typing.Union[pd.Series, pd.DataFrame]:
+        process_func_args: dict[str, object] = None,
+    ) -> pd.Series | pd.DataFrame:
         r"""Segment files or segments from a table.
 
         The labels of the table
@@ -616,7 +619,7 @@ class Segment:
         file: str = None,
         start: Timestamp = None,
         end: Timestamp = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Index:
         r"""Segment audio signal.
 
@@ -687,7 +690,7 @@ class Segment:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.Index:
         r"""Segment parts of a signal.
 

--- a/audinterface/core/segment_with_feature.py
+++ b/audinterface/core/segment_with_feature.py
@@ -167,16 +167,16 @@ class SegmentWithFeature:
         self,
         feature_names: str | Sequence[str],
         *,
-        name: str = None,
-        params: dict = None,
-        process_func: Callable[..., pd.Series] = None,
-        process_func_args: dict[str, object] = None,
-        sampling_rate: int = None,
+        name: str | None = None,
+        params: dict | None = None,
+        process_func: Callable[..., pd.Series] | None = None,
+        process_func_args: dict[str, object] | None = None,
+        sampling_rate: int | None = None,
         resample: bool = False,
         channels: int | Sequence[int] = 0,
         mixdown: bool = False,
-        min_signal_dur: Timestamp = None,
-        max_signal_dur: Timestamp = None,
+        min_signal_dur: Timestamp | None = None,
+        max_signal_dur: Timestamp | None = None,
         keep_nat: bool = False,
         num_workers: int | None = 1,
         multiprocessing: bool = False,
@@ -225,10 +225,10 @@ class SegmentWithFeature:
         self,
         file: str,
         *,
-        start: Timestamp = None,
-        end: Timestamp = None,
-        root: str = None,
-        process_func_args: dict[str, object] = None,
+        start: Timestamp | None = None,
+        end: Timestamp | None = None,
+        root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Segment the content of an audio file and extract features.
 
@@ -275,10 +275,10 @@ class SegmentWithFeature:
         self,
         files: Sequence[str],
         *,
-        starts: Timestamps = None,
-        ends: Timestamps = None,
-        root: str = None,
-        process_func_args: dict[str, object] = None,
+        starts: Timestamps | None = None,
+        ends: Timestamps | None = None,
+        root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for a list of files.
 
@@ -329,7 +329,7 @@ class SegmentWithFeature:
         *,
         filetype: str = "wav",
         include_root: bool = True,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for files in a folder.
 
@@ -385,9 +385,9 @@ class SegmentWithFeature:
         self,
         index: pd.Index,
         *,
-        root: str = None,
-        cache_root: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        cache_root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for files or segments from an index.
 
@@ -439,10 +439,10 @@ class SegmentWithFeature:
         signal: np.ndarray,
         sampling_rate: int,
         *,
-        file: str = None,
-        start: Timestamp = None,
-        end: Timestamp = None,
-        process_func_args: dict[str, object] = None,
+        file: str | None = None,
+        start: Timestamp | None = None,
+        end: Timestamp | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for audio signal.
 
@@ -497,7 +497,7 @@ class SegmentWithFeature:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: dict[str, object] = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for parts of a signal.
 
@@ -591,9 +591,9 @@ class SegmentWithFeature:
         self,
         table: pd.Series | pd.DataFrame,
         *,
-        root: str = None,
-        cache_root: str = None,
-        process_func_args: dict[str, object] = None,
+        root: str | None = None,
+        cache_root: str | None = None,
+        process_func_args: dict[str, object] | None = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for files or segments from a table.
 

--- a/audinterface/core/segment_with_feature.py
+++ b/audinterface/core/segment_with_feature.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
 import errno
 import os
-import typing
 
 import numpy as np
 import pandas as pd
@@ -162,20 +165,20 @@ class SegmentWithFeature:
 
     def __init__(
         self,
-        feature_names: typing.Union[str, typing.Sequence[str]],
+        feature_names: str | Sequence[str],
         *,
         name: str = None,
-        params: typing.Dict = None,
-        process_func: typing.Callable[..., pd.Series] = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        params: dict = None,
+        process_func: Callable[..., pd.Series] = None,
+        process_func_args: dict[str, object] = None,
         sampling_rate: int = None,
         resample: bool = False,
-        channels: typing.Union[int, typing.Sequence[int]] = 0,
+        channels: int | Sequence[int] = 0,
         mixdown: bool = False,
         min_signal_dur: Timestamp = None,
         max_signal_dur: Timestamp = None,
         keep_nat: bool = False,
-        num_workers: typing.Optional[int] = 1,
+        num_workers: int | None = 1,
         multiprocessing: bool = False,
         verbose: bool = False,
     ):
@@ -225,7 +228,7 @@ class SegmentWithFeature:
         start: Timestamp = None,
         end: Timestamp = None,
         root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Segment the content of an audio file and extract features.
 
@@ -270,12 +273,12 @@ class SegmentWithFeature:
 
     def process_files(
         self,
-        files: typing.Sequence[str],
+        files: Sequence[str],
         *,
         starts: Timestamps = None,
         ends: Timestamps = None,
         root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for a list of files.
 
@@ -326,7 +329,7 @@ class SegmentWithFeature:
         *,
         filetype: str = "wav",
         include_root: bool = True,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for files in a folder.
 
@@ -384,7 +387,7 @@ class SegmentWithFeature:
         *,
         root: str = None,
         cache_root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for files or segments from an index.
 
@@ -439,7 +442,7 @@ class SegmentWithFeature:
         file: str = None,
         start: Timestamp = None,
         end: Timestamp = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for audio signal.
 
@@ -494,7 +497,7 @@ class SegmentWithFeature:
         signal: np.ndarray,
         sampling_rate: int,
         index: pd.Index,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for parts of a signal.
 
@@ -586,11 +589,11 @@ class SegmentWithFeature:
 
     def process_table(
         self,
-        table: typing.Union[pd.Series, pd.DataFrame],
+        table: pd.Series | pd.DataFrame,
         *,
         root: str = None,
         cache_root: str = None,
-        process_func_args: typing.Dict[str, typing.Any] = None,
+        process_func_args: dict[str, object] = None,
     ) -> pd.DataFrame:
         r"""Segment and extract features for files or segments from a table.
 

--- a/audinterface/core/segment_with_feature.py
+++ b/audinterface/core/segment_with_feature.py
@@ -168,7 +168,7 @@ class SegmentWithFeature:
         feature_names: str | Sequence[str],
         *,
         name: str | None = None,
-        params: dict | None = None,
+        params: dict[str, object] | None = None,
         process_func: Callable[..., pd.Series] | None = None,
         process_func_args: dict[str, object] | None = None,
         sampling_rate: int | None = None,

--- a/audinterface/core/typing.py
+++ b/audinterface/core/typing.py
@@ -1,16 +1,10 @@
-import typing
+from __future__ import annotations
+
+from collections.abc import Sequence
 
 import pandas as pd
 
 
-Timestamp = typing.Union[
-    float,
-    int,
-    str,
-    pd.Timedelta,
-]
+Timestamp = float | int | str | pd.Timedelta
 
-Timestamps = typing.Union[
-    Timestamp,
-    typing.Sequence[Timestamp],
-]
+Timestamps = Timestamp | Sequence[Timestamp]

--- a/audinterface/core/typing.py
+++ b/audinterface/core/typing.py
@@ -1,10 +1,9 @@
-from __future__ import annotations
-
 from collections.abc import Sequence
+from typing import Union
 
 import pandas as pd
 
 
-Timestamp = float | int | str | pd.Timedelta
+Timestamp = Union[float, int, str, pd.Timedelta]
 
-Timestamps = Timestamp | Sequence[Timestamp]
+Timestamps = Union[Timestamp, Sequence[Timestamp]]

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import collections
+from collections.abc import Sequence
 import os
-import typing
 
 import numpy as np
 import pandas as pd
@@ -52,7 +54,7 @@ def assert_index(obj: pd.Index):
         audformat.assert_index(obj)
 
 
-def is_scalar(value: typing.Any) -> bool:
+def is_scalar(value: object) -> bool:
     r"""Check if value is scalar."""
     return (value is not None) and (
         isinstance(value, str) or not hasattr(value, "__len__")
@@ -64,9 +66,9 @@ def preprocess_signal(
     sampling_rate: int,
     expected_rate: int,
     resample: bool,
-    channels: typing.Union[int, typing.Sequence[int]],
+    channels: int | Sequence[int],
     mixdown: bool,
-) -> (np.ndarray, int):
+) -> tuple[np.ndarray, int]:
     r"""Pre-process signal."""
     signal = np.atleast_2d(signal)
 
@@ -99,7 +101,7 @@ def read_audio(
     start: pd.Timedelta = None,
     end: pd.Timedelta = None,
     root: str = None,
-) -> typing.Tuple[np.ndarray, int]:
+) -> tuple[np.ndarray, int]:
     """Reads (segment of an) audio file.
 
     Args:
@@ -153,7 +155,7 @@ def segment_to_indices(
     sampling_rate: int,
     start: pd.Timedelta,
     end: pd.Timedelta,
-) -> typing.Tuple[int, int]:
+) -> tuple[int, int]:
     if pd.isna(end):
         end = pd.to_timedelta(signal.shape[-1] / sampling_rate, unit="s")
     max_i = signal.shape[-1]
@@ -168,7 +170,7 @@ def segments_to_indices(
     signal: np.ndarray,
     sampling_rate: int,
     index: pd.MultiIndex,
-) -> typing.Tuple[typing.Sequence[int], typing.Sequence[int]]:
+) -> tuple[Sequence[int], Sequence[int]]:
     starts_i = [0] * len(index)
     ends_i = [0] * len(index)
     for idx, (start, end) in enumerate(index):
@@ -372,7 +374,7 @@ def sliding_window(
     return frames
 
 
-def to_array(value: typing.Any) -> np.ndarray:
+def to_array(value: object) -> np.ndarray:
     r"""Convert value to numpy array."""
     if value is not None:
         if isinstance(value, (pd.Series, pd.DataFrame, pd.Index)):
@@ -385,7 +387,7 @@ def to_array(value: typing.Any) -> np.ndarray:
 def to_timedelta(
     durations: Timestamps,
     sampling_rate: int = None,
-) -> typing.Union[pd.Timedelta, typing.List[pd.Timedelta]]:
+) -> pd.Timedelta | list[pd.Timedelta]:
     r"""Convert duration value(s) to :class:`pandas.Timedelta`.
 
     The single duration values

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -64,9 +64,9 @@ def is_scalar(value: object) -> bool:
 def preprocess_signal(
     signal: np.ndarray,
     sampling_rate: int,
-    expected_rate: int,
+    expected_rate: int | None,
     resample: bool,
-    channels: int | Sequence[int],
+    channels: int | Sequence[int] | None,
     mixdown: bool,
 ) -> tuple[np.ndarray, int]:
     r"""Pre-process signal."""
@@ -98,9 +98,9 @@ def preprocess_signal(
 def read_audio(
     file: str,
     *,
-    start: pd.Timedelta = None,
-    end: pd.Timedelta = None,
-    root: str = None,
+    start: pd.Timedelta | None = None,
+    end: pd.Timedelta | None = None,
+    root: str | None = None,
 ) -> tuple[np.ndarray, int]:
     """Reads (segment of an) audio file.
 
@@ -181,8 +181,8 @@ def segments_to_indices(
 
 
 def signal_index(
-    starts: Timestamps = None,
-    ends: Timestamps = None,
+    starts: Timestamps | None = None,
+    ends: Timestamps | None = None,
 ) -> pd.MultiIndex:
     r"""Create signal index.
 
@@ -386,7 +386,7 @@ def to_array(value: object) -> np.ndarray:
 
 def to_timedelta(
     durations: Timestamps,
-    sampling_rate: int = None,
+    sampling_rate: int | None = None,
 ) -> pd.Timedelta | list[pd.Timedelta]:
     r"""Convert duration value(s) to :class:`pandas.Timedelta`.
 


### PR DESCRIPTION
Updates syntax to Python >=3.9 by removing the use of `typing`.

## Summary by Sourcery

Update type hints across core modules to use Python 3.9+ syntax, replacing typing module constructs with PEP 585 generics and the native union operator.

Enhancements:
- Adopt PEP 585 built-in generics by replacing typing.Dict, typing.List, typing.Tuple, and typing.Callable with dict, list, tuple, and Callable annotations
- Replace typing.Union and typing.Optional with the native | union operator and import Sequence from collections.abc
- Add __future__.annotations and remove redundant typing imports to streamline type hints for Python >=3.9