### PR TITLE
Remove support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
     - uses: actions/checkout@v4

--- a/audinterface/core/feature.py
+++ b/audinterface/core/feature.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 from collections.abc import Sequence
 import errno

--- a/audinterface/core/process.py
+++ b/audinterface/core/process.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 from collections.abc import Sequence
 import errno

--- a/audinterface/core/process_with_context.py
+++ b/audinterface/core/process_with_context.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import collections
 from collections.abc import Callable
 from collections.abc import Sequence

--- a/audinterface/core/segment.py
+++ b/audinterface/core/segment.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 from collections.abc import Sequence
 import errno

--- a/audinterface/core/segment_with_feature.py
+++ b/audinterface/core/segment_with_feature.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 from collections.abc import Sequence
 import errno

--- a/audinterface/core/utils.py
+++ b/audinterface/core/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import collections
 from collections.abc import Sequence
 import os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,13 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 dependencies = [
     'audeer >=2.1.1',
     'audformat >=1.0.1,<2.0.0',


### PR DESCRIPTION
Remove support for Python 3.9.

## Summary by Sourcery

Drop Python 3.9 support by updating package metadata and CI configurations to require and test on Python 3.10 and above

Enhancements:
- Remove support for Python 3.9 across project metadata and configurations

Build:
- Bump requires-python version in pyproject.toml from >=3.9 to >=3.10

CI:
- Update CI matrix to test only on Python 3.10 and newer