### PR TITLE
CI: update checkout, setup-python, setup-uv, codecov

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,21 +16,21 @@ jobs:
         python-version: [ '3.10' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Cache emodb
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb
         key: emodb-1.3.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Ubuntu - install libsndfile1 and portaudio
       run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,6 +31,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Ubuntu - install libsndfile1 and portaudio
       run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
 
     # PyPI package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,17 +16,17 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
 
     # PyPI package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,21 +16,21 @@ jobs:
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Cache emodb
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb
         key: emodb-1.3.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Prepare Macos
       run: |
@@ -50,8 +50,8 @@ jobs:
       run: uv run pytest
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Prepare Macos
       run: |


### PR DESCRIPTION
## Summary

Two related CI bugs, both caused by stale GitHub Action version pins:

1. **Dead uv caching**: `astral-sh/setup-uv`'s default `cache-dependency-glob`
   keys on `uv.lock`/`requirements*.txt`, neither of which exists here (no
   committed lockfile, by design), so caching never actually worked. Bumped
   `astral-sh/setup-uv` `v5` -> `v9.0.0`: `v6.0.0` added `pyproject.toml` to
   the default glob, which is committed and changes exactly when a
   dependency does, so caching now works with no lockfile needed.

2. **Node.js 20 deprecation**: `actions/checkout` and `actions/setup-python`
   bumped `v4`/`v5` -> `v7`, clearing the "Node.js 20 is deprecated" warning.
   `codecov/codecov-action` bumped `v4` -> `v7`; its `v5` rewrite dropped the
   singular `file:` input in favor of `files:`, renamed accordingly.
   `actions/cache` (used for the emodb test-data cache in doc/test
   workflows) bumped `v4` -> `v6` for the same reason.

`prune-cache` left at its new default (off): audinterface's dependency tree
(audeer, audformat, audiofile, audmath, audresample) has no large
pre-built binary wheels like torch, so pruning would save ~0 disk space
while costing avoidable re-downloads.

Part of the same CI cleanup as audeering/audeer#206,
audeering/opensmile-python#132, audeering/audb#591,
audeering/audformat#539, audeering/audbackend#307, and
audeering/audresample#83.

## Test plan

- [x] All workflow YAML files reviewed and diff-verified against the
      established pattern from sibling repos
- [ ] CI passes on this PR